### PR TITLE
Deal with invalid ROIs in dff_traces and events tables

### DIFF
--- a/mindscope_utilities/ophys/data_formatting.py
+++ b/mindscope_utilities/ophys/data_formatting.py
@@ -1,7 +1,8 @@
 import pandas as pd
+import numpy as np
 
 
-def build_tidy_cell_df(experiment):
+def build_tidy_cell_df(experiment, exclude_invalid_rois=True):
     '''
     Builds a tidy dataframe describing activity for every cell in experiment.
     Tidy format is defined as one row per observation.
@@ -12,6 +13,10 @@ def build_tidy_cell_df(experiment):
     experiment : AllenSDK BehaviorOphysExperiment object
         A BehaviorOphysExperiment instance
         See https://github.com/AllenInstitute/AllenSDK/blob/master/allensdk/brain_observatory/behavior/behavior_ophys_experiment.py  # noqa E501
+    exclude_invalid_rois : bool
+        If True (default), only includes ROIs that are listed as `valid_roi = True` in the experiment.cell_specimen_table.
+        If False, include all ROIs.
+        Note that invalid ROIs are only exposed for internal AllenInstitute users, so passing `False` will not change behavior for external users
 
     Returns:
     --------
@@ -28,17 +33,25 @@ def build_tidy_cell_df(experiment):
     # make an empty list to populate with dataframes for each cell
     list_of_cell_dfs = []
 
+    # query on valid_roi if exclude_invalid_rois == True
+    if exclude_invalid_rois:
+        cell_specimen_table = experiment.cell_specimen_table.query('valid_roi').reset_index()  # noqa E501
+    else:
+        cell_specimen_table = experiment.cell_specimen_table.reset_index()
+
     # iterate over each individual cell
-    for cell_specimen_id in experiment.dff_traces.reset_index()['cell_specimen_id']:  # noqa E501
+    for idx, row in cell_specimen_table.iterrows():
+        cell_specimen_id = row['cell_specimen_id']
+        cell_roi_id = row['cell_roi_id']
 
         # build a tidy dataframe for this cell
         cell_df = pd.DataFrame({
             'timestamps': experiment.ophys_timestamps,
-            'cell_roi_id': [experiment.dff_traces.loc[cell_specimen_id]['cell_roi_id']] * len(experiment.ophys_timestamps),  # noqa E501
+            'cell_roi_id': [cell_roi_id] * len(experiment.ophys_timestamps),
             'cell_specimen_id': [cell_specimen_id] * len(experiment.ophys_timestamps),  # noqa E501
             'dff': experiment.dff_traces.loc[cell_specimen_id]['dff'],
-            'events': experiment.events.loc[cell_specimen_id]['events'],
-            'filtered_events': experiment.events.loc[cell_specimen_id]['filtered_events'],  # noqa E501
+            'events': experiment.events.loc[cell_specimen_id]['events'] if cell_specimen_id in experiment.events.index else [np.nan] * len(experiment.ophys_timestamps),  # noqa E501
+            'filtered_events': experiment.events.loc[cell_specimen_id]['filtered_events'] if cell_specimen_id in experiment.events.index else [np.nan] * len(experiment.ophys_timestamps),  # noqa E501
         })
 
         # append the dataframe for this cell to the list of cell dataframes

--- a/mindscope_utilities/ophys/data_formatting.py
+++ b/mindscope_utilities/ophys/data_formatting.py
@@ -49,7 +49,7 @@ def build_tidy_cell_df(experiment, exclude_invalid_rois=True):
             'timestamps': experiment.ophys_timestamps,
             'cell_roi_id': [cell_roi_id] * len(experiment.ophys_timestamps),
             'cell_specimen_id': [cell_specimen_id] * len(experiment.ophys_timestamps),  # noqa E501
-            'dff': experiment.dff_traces.loc[cell_specimen_id]['dff'] if cell_specimen_id in experiment.dff_traces.index else [np.nan] * len(experiment.ophys_timestamps),
+            'dff': experiment.dff_traces.loc[cell_specimen_id]['dff'] if cell_specimen_id in experiment.dff_traces.index else [np.nan] * len(experiment.ophys_timestamps),  # noqa E501
             'events': experiment.events.loc[cell_specimen_id]['events'] if cell_specimen_id in experiment.events.index else [np.nan] * len(experiment.ophys_timestamps),  # noqa E501
             'filtered_events': experiment.events.loc[cell_specimen_id]['filtered_events'] if cell_specimen_id in experiment.events.index else [np.nan] * len(experiment.ophys_timestamps),  # noqa E501
         })

--- a/mindscope_utilities/ophys/data_formatting.py
+++ b/mindscope_utilities/ophys/data_formatting.py
@@ -49,7 +49,7 @@ def build_tidy_cell_df(experiment, exclude_invalid_rois=True):
             'timestamps': experiment.ophys_timestamps,
             'cell_roi_id': [cell_roi_id] * len(experiment.ophys_timestamps),
             'cell_specimen_id': [cell_specimen_id] * len(experiment.ophys_timestamps),  # noqa E501
-            'dff': experiment.dff_traces.loc[cell_specimen_id]['dff'],
+            'dff': experiment.dff_traces.loc[cell_specimen_id]['dff'] if cell_specimen_id in experiment.dff_traces.index else [np.nan] * len(experiment.ophys_timestamps),
             'events': experiment.events.loc[cell_specimen_id]['events'] if cell_specimen_id in experiment.events.index else [np.nan] * len(experiment.ophys_timestamps),  # noqa E501
             'filtered_events': experiment.events.loc[cell_specimen_id]['filtered_events'] if cell_specimen_id in experiment.events.index else [np.nan] * len(experiment.ophys_timestamps),  # noqa E501
         })

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,8 @@ class SimulatedExperiment(object):
         list of cell specimen IDs
     cell_roi_ids : list of ints
         list of cell ROI IDs
+    valid_rois : list of bools
+        list of validity state for each ROI
     timestamps : list of floats
         measurement timestamps
     dff : list of lists/arrays of floats
@@ -30,13 +32,22 @@ class SimulatedExperiment(object):
     --------
     simulated AllenSDK BehaviorOphysExperiment object
     '''
-    def __init__(self, cell_specimen_ids, cell_roi_ids, timestamps, dff, events, filtered_events):
+    def __init__(self, cell_specimen_ids, cell_roi_ids, valid_rois, timestamps, dff, events, filtered_events):
+
         self.ophys_timestamps = np.array(timestamps)
+
+        self.cell_specimen_table = self.build_cell_specimen_table(
+            cell_specimen_ids,
+            cell_roi_ids,
+            valid_rois
+        )
+
         self.dff_traces = self.build_dff_traces(
             cell_specimen_ids,
             cell_roi_ids,
             dff
         )
+
         self.events = self.build_events(
             cell_specimen_ids,
             cell_roi_ids,
@@ -44,6 +55,15 @@ class SimulatedExperiment(object):
             filtered_events
         )
         
+    def build_cell_specimen_table(self, cell_specimen_ids, cell_roi_ids, valid_rois):
+        '''builds a cell_specimen_table dataframe'''
+        cell_specimen_table = pd.DataFrame({
+            'cell_specimen_id': cell_specimen_ids,
+            'cell_roi_id': cell_roi_ids,
+            'valid_roi': valid_rois,
+        })
+        return cell_specimen_table.set_index('cell_specimen_id')
+
     def build_dff_traces(self, cell_specimen_ids, cell_roi_ids, dff):
         '''builds a dff_traces dataframe'''
         dff_traces = pd.DataFrame({
@@ -69,10 +89,14 @@ class SimulatedExperiment(object):
 def simulated_experiment_fixture():
    # build a simulated experiment
     timestamps = np.arange(0, 1, 0.01)
-    cell_specimen_ids = [1, 2, 3]
+    cell_specimen_ids = [1, 2, 3, 4]
+    cell_roi_ids = [2*csid for csid in cell_specimen_ids]
+    valid_rois = [True, True, True, False]
+
     simulated_experiment = SimulatedExperiment(
         cell_specimen_ids = cell_specimen_ids,
-        cell_roi_ids = [2*csid for csid in cell_specimen_ids],
+        cell_roi_ids = cell_roi_ids,
+        valid_rois = valid_rois,
         timestamps = timestamps,
         dff = [np.sin(2*np.pi*timestamps + ii*0.5*np.pi) for ii, cell in enumerate(cell_specimen_ids)],
         events = [np.sin(4*np.pi*timestamps+ ii*0.5*np.pi) for ii, cell in enumerate(cell_specimen_ids)],


### PR DESCRIPTION
Solves issue #3 

* Adds a boolean flag exclude_invalid_rois which defaults to True. If False, invalid ROIs will be included
* iterates over cells in cell_specimen_table, rather than dff_traces
* adds NaNs for missing cells