### PR TITLE
Make cols categorical

### DIFF
--- a/mindscope_utilities/__init__.py
+++ b/mindscope_utilities/__init__.py
@@ -1,4 +1,4 @@
 from .general_utilities import *  # noqa: F401,F403
 from .plotting_utilities import *  # noqa: F401,F403
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -1,6 +1,5 @@
 import pandas as pd
 import numpy as np
-from tqdm import tqdm
 
 
 def build_tidy_cell_df(experiment, exclude_invalid_rois=True):

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -42,7 +42,7 @@ def build_tidy_cell_df(experiment, exclude_invalid_rois=True):
     # iterate over each individual cell
     for idx, row in cell_specimen_table.iterrows():
         cell_specimen_id = row['cell_specimen_id']
-        cell_roi_id = row['cell_roi_id']
+
         # build a tidy dataframe for this cell
         cell_df = pd.DataFrame({
             'timestamps': experiment.ophys_timestamps,
@@ -51,11 +51,15 @@ def build_tidy_cell_df(experiment, exclude_invalid_rois=True):
             'filtered_events': experiment.events.loc[cell_specimen_id]['filtered_events'] if cell_specimen_id in experiment.events.index else [np.nan] * len(experiment.ophys_timestamps),  # noqa E501
         })
 
-        # Make the cell_roi_id and cell_specimen_id columns categorical. 
-        # This will reduce memory useage since the columns consist of many repeated values.
+        # Make the cell_roi_id and cell_specimen_id columns categorical.
+        # This will reduce memory useage since the columns
+        # consist of many repeated values.
         for cell_id in ['cell_roi_id', 'cell_specimen_id']:
             cell_df[cell_id] = np.int32(row[cell_id])
-            cell_df[cell_id] = pd.Categorical(cell_df[cell_id], categories = cell_specimen_table[cell_id].unique())
+            cell_df[cell_id] = pd.Categorical(
+                cell_df[cell_id],
+                categories=cell_specimen_table[cell_id].unique()
+            )
 
         # append the dataframe for this cell to the list of cell dataframes
         list_of_cell_dfs.append(cell_df)

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import numpy as np
+from tqdm import tqdm
 
 
 def build_tidy_cell_df(experiment, exclude_invalid_rois=True):
@@ -43,16 +44,19 @@ def build_tidy_cell_df(experiment, exclude_invalid_rois=True):
     for idx, row in cell_specimen_table.iterrows():
         cell_specimen_id = row['cell_specimen_id']
         cell_roi_id = row['cell_roi_id']
-
         # build a tidy dataframe for this cell
         cell_df = pd.DataFrame({
             'timestamps': experiment.ophys_timestamps,
-            'cell_roi_id': [cell_roi_id] * len(experiment.ophys_timestamps),
-            'cell_specimen_id': [cell_specimen_id] * len(experiment.ophys_timestamps),  # noqa E501
             'dff': experiment.dff_traces.loc[cell_specimen_id]['dff'] if cell_specimen_id in experiment.dff_traces.index else [np.nan] * len(experiment.ophys_timestamps),  # noqa E501
             'events': experiment.events.loc[cell_specimen_id]['events'] if cell_specimen_id in experiment.events.index else [np.nan] * len(experiment.ophys_timestamps),  # noqa E501
             'filtered_events': experiment.events.loc[cell_specimen_id]['filtered_events'] if cell_specimen_id in experiment.events.index else [np.nan] * len(experiment.ophys_timestamps),  # noqa E501
         })
+
+        # Make the cell_roi_id and cell_specimen_id columns categorical. 
+        # This will reduce memory useage since the columns consist of many repeated values.
+        for cell_id in ['cell_roi_id', 'cell_specimen_id']:
+            cell_df[cell_id] = np.int32(row[cell_id])
+            cell_df[cell_id] = pd.Categorical(cell_df[cell_id], categories = cell_specimen_table[cell_id].unique())
 
         # append the dataframe for this cell to the list of cell dataframes
         list_of_cell_dfs.append(cell_df)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='mindscope_utilities',
-    version='0.1.6',
+    version='0.1.7',
     packages=['mindscope_utilities'],
     include_package_data = True,
     description='Utilities for loading, manipulating and visualizing data from the Allen Institute Mindscope program',

--- a/tests/mindscope_utilities/visual_behavior_ophys/test_data_formatting.py
+++ b/tests/mindscope_utilities/visual_behavior_ophys/test_data_formatting.py
@@ -18,10 +18,12 @@ def test_build_tidy_cell_df(simulated_experiment_fixture):
         'events': 0.0,
         'filtered_events': 1.0
     }])
-    pd.testing.assert_frame_equal(
-        tidy_cell_df.query('cell_specimen_id == 1 and timestamps == 0.5').reset_index(drop=True),
-        ans_1
-    )
+    ans_1['cell_specimen_id'] = pd.Categorical(ans_1['cell_specimen_id'], categories=[1, 2, 3])
+    ans_1['cell_roi_id'] = pd.Categorical(ans_1['cell_roi_id'], categories=[2, 4, 6])
+    
+    cols = ['timestamps', 'cell_roi_id', 'cell_specimen_id', 'dff', 'events', 'cell_specimen_id']
+    actual_1 = tidy_cell_df.query('cell_specimen_id == 1 and timestamps == 0.5').reset_index(drop=True)
+    pd.testing.assert_frame_equal(actual_1[cols], ans_1[cols])
 
     ans_2 = pd.DataFrame([{
         'timestamps': 0.5,
@@ -31,7 +33,8 @@ def test_build_tidy_cell_df(simulated_experiment_fixture):
         'events': 1.0,
         'filtered_events': 0.0
     }])
-    pd.testing.assert_frame_equal(
-        tidy_cell_df.query('cell_specimen_id == 2 and timestamps == 0.5').reset_index(drop=True),
-        ans_2
-    )
+    ans_2['cell_specimen_id'] = pd.Categorical(ans_2['cell_specimen_id'], categories=[1, 2, 3])
+    ans_2['cell_roi_id'] = pd.Categorical(ans_2['cell_roi_id'], categories=[2, 4, 6])
+    actual_2 = tidy_cell_df.query('cell_specimen_id == 2 and timestamps == 0.5').reset_index(drop=True)
+    pd.testing.assert_frame_equal(actual_2[cols], ans_2[cols])
+


### PR DESCRIPTION
Addresses issue #18. Makes the `cell_roi_id` and `cell_specimen_id` columns categorical in the tidy neural dataframe. This limits data usage given that IDs are repeated many thousands of times.