### PR TITLE
update time array method to ensure desired frequency

### DIFF
--- a/mindscope_utilities/general_utilities.py
+++ b/mindscope_utilities/general_utilities.py
@@ -2,10 +2,11 @@ import pandas as pd
 import numpy as np
 
 
-def get_time_array(t_start, t_end, sampling_rate=None, step_size=None, include_endpoint=True):
+def get_time_array(t_start, t_end, sampling_rate=None, step_size=None, include_endpoint=True):  # NOQA E501
     '''
-    A function to get a time array between two specified timepoints at a defined sampling rate
-    Deals with possibility of time range not being evenly divisible by desired sampling rate
+    A function to get a time array between two specified timepoints at a defined sampling rate  # NOQA E501
+    Deals with possibility of time range not being evenly divisible by desired sampling rate  # NOQA E501
+    Uses np.linspace instead of np.arange given decimal precision issues with np.arange (see np.arange documentation for details)  # NOQA E501
 
     Parameters:
     -----------
@@ -28,9 +29,55 @@ def get_time_array(t_start, t_end, sampling_rate=None, step_size=None, include_e
     --------
     numpy.array
         an array of timepoints at the desired sampling rate
+
+    Examples:
+    ---------
+    get a time array exclusive of the endpoint
+    >>> t_array = get_time_array(
+        t_start=-1, 
+        t_end=1, 
+        step_size=0.5,
+        include_endpoint=False
+    )
+
+    np.array([-1., -0.5,  0.,  0.5])
+
+
+    get a time array inclusive of the endpoint
+    >>> t_array = get_time_array(
+        t_start=-1, 
+        t_end=1, 
+        step_size=0.5,
+        include_endpoint=False
+    )
+
+    np.array([-1., -0.5,  0.,  0.5, 1.0])
+
+
+    get a time array where the range can't be evenly divided by the desired step_size
+    in this case, the time array includes the last timepoint before the desired endpoint
+    >>> t_array = get_time_array(
+        t_start=-1, 
+        t_end=0.75, 
+        step_size=0.5,
+        include_endpoint=False
+    )
+
+    np.array([-1., -0.5,  0.,  0.5])
+
+
+    Instead of passing the step_size, we can pass the sampling rate
+    >>> t_array = get_time_array(
+        t_start=-1, 
+        t_end=1, 
+        sampling_rate=2,
+        include_endpoint=False
+    )
+
+    np.array([-1., -0.5,  0.,  0.5])
     '''
-    assert sampling_rate is not None or step_size is not None, 'must specify either sampling_rate or step_size'
-    assert sampling_rate is None or step_size is None, 'cannot specify both sampling_rate and step_size'
+    assert sampling_rate is not None or step_size is not None, 'must specify either sampling_rate or step_size'  # NOQA E501
+    assert sampling_rate is None or step_size is None, 'cannot specify both sampling_rate and step_size'  # NOQA E501
 
     # value as a linearly spaced time array
     if not step_size:

--- a/mindscope_utilities/general_utilities.py
+++ b/mindscope_utilities/general_utilities.py
@@ -104,14 +104,22 @@ def event_triggered_response(data, t, y, event_times, t_before=1, t_after=1, out
     # set up a dictionary with key 'time' and
     # value as a linearly spaced time array
     step_size = 1/output_sampling_rate
-    data_dict = {
-        'time': np.linspace(
-            -t_before,
-            t_after,
-            int((t_before + t_after) / step_size + int(include_endpoint)),
-            endpoint=include_endpoint
-        )
-    }
+    # define a time array
+    n_steps = (t_before + t_after) / step_size
+    if n_steps != int(n_steps):
+        # if the number of steps isn't an int, that means it isn't possible
+        # to end on the desired t_after using the defined sampling rate
+        # we need to round down and include the endpoint
+        n_steps = int(n_steps)
+        t_after = -1*t_before + n_steps*step_size
+        include_endpoint = True
+
+    if include_endpoint:
+        # add an extra step if including endpoint
+        n_steps += 1
+
+    t_array = np.linspace(-t_before, t_after, int(n_steps), endpoint=include_endpoint)
+    data_dict = {'time': t_array}
 
     # iterate over all event times
     data_time_indexed = data.set_index(t, inplace=False)

--- a/mindscope_utilities/general_utilities.py
+++ b/mindscope_utilities/general_utilities.py
@@ -118,7 +118,8 @@ def event_triggered_response(data, t, y, event_times, t_before=1, t_after=1, out
         # add an extra step if including endpoint
         n_steps += 1
 
-    t_array = np.linspace(-t_before, t_after, int(n_steps), endpoint=include_endpoint)
+    t_array = np.linspace(-t_before, t_after, int(n_steps),
+                          endpoint=include_endpoint)
     data_dict = {'time': t_array}
 
     # iterate over all event times

--- a/tests/mindscope_utilities/test_general_utilities.py
+++ b/tests/mindscope_utilities/test_general_utilities.py
@@ -1,6 +1,121 @@
 import numpy as np
 import pandas as pd
-from mindscope_utilities import event_triggered_response
+from mindscope_utilities import event_triggered_response, get_time_array
+
+def test_get_time_array_with_sampling_rate():
+    '''
+    tests the `get_time_array` function while passing a sampling_rate argument
+    '''
+    # this should give [-1, 1) with steps of 0.5, exclusive of the endpoint
+    t_array = get_time_array(
+        t_start=-1, 
+        t_end=1, 
+        sampling_rate=2,
+        include_endpoint=False
+    )
+    assert (t_array == np.array([-1., -0.5,  0.,  0.5])).all()
+
+    # this should give [-1, 1] with steps of 0.5, inclusive of the endpoint
+    t_array = get_time_array(
+        t_start=-1, 
+        t_end=1, 
+        sampling_rate=2,
+        include_endpoint=True
+    )
+    assert (t_array == np.array([-1., -0.5,  0.,  0.5, 1.0])).all()
+
+    # this should give [-1, 0.75) with steps of 0.5.
+    # becuase the desired range (1.75) is not evenly divisible by the step size (0.5), the array should end before the desired endpoint
+    t_array = get_time_array(
+        t_start=-1, 
+        t_end=0.75, 
+        sampling_rate=2,
+        include_endpoint=False
+    )
+    assert (t_array == np.array([-1., -0.5,  0.,  0.5])).all()
+
+    # this should give [-1, 0.75) with steps of 0.5.
+    # becuase the desired range (1.75) is not evenly divisible by the step size (0.5), the array should end before the desired endpoint
+    t_array = get_time_array(
+        t_start=-1, 
+        t_end=0.75, 
+        sampling_rate=2,
+        include_endpoint=True
+    )
+    assert (t_array == np.array([-1., -0.5,  0.,  0.5])).all()
+
+
+def test_get_time_array_with_step_size():
+    '''
+    tests the `get_time_array` function while passing a step_size argument
+    '''
+    # this should give [-1, 1) with steps of 0.5, exclusive of the endpoint
+    t_array = get_time_array(
+        t_start=-1, 
+        t_end=1, 
+        step_size=0.5,
+        include_endpoint=False
+    )
+    assert (t_array == np.array([-1., -0.5,  0.,  0.5])).all()
+
+    # this should give [-1, 1] with steps of 0.5, inclusive of the endpoint
+    t_array = get_time_array(
+        t_start=-1, 
+        t_end=1, 
+        step_size=0.5,
+        include_endpoint=True
+    )
+    assert (t_array == np.array([-1., -0.5,  0.,  0.5, 1.0])).all()
+
+    # this should give [-1, 0.75) with steps of 0.5.
+    # becuase the desired range (1.75) is not evenly divisible by the step size (0.5), the array should end before the desired endpoint
+    t_array = get_time_array(
+        t_start=-1, 
+        t_end=0.75, 
+        step_size=0.5,
+        include_endpoint=False
+    )
+    assert (t_array == np.array([-1., -0.5,  0.,  0.5])).all()
+
+    # this should give [-1, 0.75) with steps of 0.5.
+    # becuase the desired range (1.75) is not evenly divisible by the step size (0.5), the array should end before the desired endpoint
+    t_array = get_time_array(
+        t_start=-1, 
+        t_end=0.75, 
+        step_size=0.5,
+        include_endpoint=True
+    )
+    assert (t_array == np.array([-1., -0.5,  0.,  0.5])).all()
+
+
+def test_get_time_array_assertion_errors():
+    '''
+    tests that assertion errors are working correctly in `get_time_array`
+    '''
+    try:
+        t_array = get_time_array(
+            t_start=-1, 
+            t_end=1, 
+            sampling_rate=2,
+            step_size=0.5,
+            include_endpoint=False
+        )
+        assert False, 'it should not be possible to pass both sampling_rate and step_size'
+    except AssertionError:
+        # expect the AssertionError, so this test should pass
+        pass
+
+    try:
+        t_array = get_time_array(
+            t_start=-1, 
+            t_end=1, 
+            include_endpoint=False
+        )
+        assert False, 'must pass either a sampling_rate or step_size'
+    except AssertionError:
+        # expect the AssertionError, so this test should pass
+        pass
+
 
 def test_event_triggered_response():
     # make a time vector from -10 to 110


### PR DESCRIPTION
Updates the time array calculation method in `event_triggered_response` to ensure that the desired sampling frequency is maintained even if the desired time range isn't evenly divisible by the resulting timestep.

For example, if you want a time range from 0 to 0.75 seconds at 30Hz, this new method would round your actual endpoint down to 0.7333 ms to ensure that you have even timesteps that are 33ms long.

Closes #23 