### PR TITLE
Adding functions to calculate and plot d' and response matrices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ dmypy.json
 .idea/mindscope_utilities.iml
 
 .idea/misc.xml
+
+# cached NWB files
+.nwb_cache/

--- a/mindscope_utilities/general_utilities.py
+++ b/mindscope_utilities/general_utilities.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import numpy as np
+from scipy.stats import norm
 
 
 def get_time_array(t_start, t_end, sampling_rate=None, step_size=None, include_endpoint=True):  # NOQA E501
@@ -396,3 +397,228 @@ def event_triggered_response(data, t, y, event_times, t_start=None, t_end=None, 
         )
         # return the tidy event triggered responses
         return tidy_etr
+
+def dprime(hit_rate=None, fa_rate=None, go_trials=None, catch_trials=None, limits=False):
+    '''
+    calculates the d-prime for a given hit rate and false alarm rate
+
+    https://en.wikipedia.org/wiki/Sensitivity_index
+
+    Parameters
+    ----------
+    hit_rate : float or vector of floats
+        rate of hits in the True class
+    fa_rate : float or vector of floats
+        rate of false alarms in the False class
+    go_trials: vector of booleans
+        responses on all go trials (hit = True, miss = False)
+    catch_trials: vector of booleans
+        responses on all catch trials (false alarm = True, correct reject = False)
+    limits : boolean or tuple, optional
+        limits on extreme values, which can cause d' to overestimate on low trial counts.
+        False (default) results in limits of (0.01,0.99) to avoid infinite calculations
+        True results in limits being calculated based on trial count (only applicable if go_trials and catch_trials are passed)
+        (limits[0], limits[1]) results in specified limits being applied
+
+    Note: user must pass EITHER hit_rate and fa_rate OR go_trials and catch trials
+
+    Returns
+    -------
+    d_prime
+
+    Examples
+    --------
+    With hit and false alarm rates of 0 and 1, if we pass in limits of (0, 1) we are
+    allowing the raw probabilities to be used in the dprime calculation.
+    This will result in an infinite dprime:
+
+    >> dprime(hit_rate = 1.0, fa_rate = 0.0, limits = (0, 1))
+    np.inf
+
+    If we do not pass limits, the default limits of 0.01 and 0.99 will be used
+    which will convert the hit rate of 1 to 0.99 and the false alarm rate of 0 to 0.01.
+    This will prevent the d' calcluation from being infinite:
+
+    >>> dprime(hit_rate = 1.0, fa_rate = 0.0)
+    4.6526957480816815
+
+    If the hit and false alarm rates are already within the limits, the limits don't apply
+    >>> dprime(hit_rate = 0.6, fa_rate = 0.4)
+    0.5066942062715994
+
+    Alternately, instead of passing in pre-computed hit and false alarm rates,
+    we can pass in a vector of results on go-trials and catch-trials.
+    Then, if we call `limits = True`, the limits will be calculated based
+    on the number of trials in both the go and catch trial vectors
+    using the `trial_number_limit` function.
+
+    For example, for low trial counts, even perfect performance (hit rate = 1, false alarm rate = 0)
+    leads to a lower estimate of d', given that we have low confidence in the hit and false alarm rates;
+
+    >>> dprime(
+            go_trials = [1, 1, 1],
+            catch_trials = [0, 0],
+            limits = True
+            )
+    1.6419113162977828
+
+    At the limit, if we have only one sample of both trial types, the `trial_number_limit`
+    pushes our estimated response probability to 0.5 for both the hit and false alarm rates,
+    giving us a d' value of 0:
+
+    >>> dprime(
+            go_trials = [1],
+            catch_trials = [0],
+            limits = True
+            )
+    0.0
+
+    And with higher trial counts, the `trial_number_limit` allows the hit and false alarm
+    rates to get asymptotically closer to 0 and 1, leading to higher values of d'.
+    For example, for 10 trials of each type:
+
+    >>> dprime(
+            go_trials = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            catch_trials = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            limits = True
+        )
+    3.289707253902945
+
+    Or, if we had 20 hit trials and 10 false alarm trials:
+
+    >>> dprime(
+            go_trials = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            catch_trials = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            limits = True
+        )
+    3.604817611491527
+
+    Note also that Boolean vectors can be passed:
+
+    >>> dprime(
+            go_trials = [True, False, True, True, False],
+            catch_trials = [False, True, False, False, False],
+            limits = True
+        )
+    1.094968336708714
+    '''
+
+    assert hit_rate is not None or go_trials is not None, 'must either a specify `hit_rate` or pass a boolean vector of `go_trials`'
+    assert fa_rate is not None or catch_trials is not None, 'must either a specify `fa_rate` or pass a boolean vector of `catch_trials`'
+
+    assert hit_rate is None or go_trials is None, 'do not pass both `hit_rate` and a boolean vector of `go_trials`'
+    assert fa_rate is None or catch_trials is None, 'do not pass both `fa_rate` and a boolean vector of `catch_trials`'
+
+    assert not (hit_rate is not None and limits == True), 'limits can only be calculated if a go_trials vector is passed, not a hit_rate'
+    assert not (fa_rate is not None and limits == True), 'limits can only be calculated if a catch_trials vector is passed, not a fa_rate'
+
+    # calculate hit and fa rates as mean of boolean vectors
+    if hit_rate is None:
+        hit_rate = np.mean(go_trials)
+    if fa_rate is None:
+        fa_rate = np.mean(catch_trials)
+
+    Z = norm.ppf
+
+    if limits == False:
+        # if limits are False, apply default
+        limits = (0.01, 0.99)
+    elif limits == True:
+        # clip the hit and fa rate based on trial count
+        hit_rate = response_probabilities_trial_number_limit(hit_rate, len(go_trials))
+        fa_rate = response_probabilities_trial_number_limit(fa_rate, len(catch_trials))
+
+    if limits != True:
+        # Limit values in order to avoid d' infinity
+        hit_rate = np.clip(hit_rate, limits[0], limits[1])
+        fa_rate = np.clip(fa_rate, limits[0], limits[1])
+
+    # keep track of nan locations
+    hit_rate = pd.Series(hit_rate)
+    fa_rate = pd.Series(fa_rate)
+    hit_rate_nan_locs = list(hit_rate[pd.isnull(hit_rate)].index)
+    fa_rate_nan_locs = list(fa_rate[pd.isnull(fa_rate)].index)
+
+    # fill nans with 0.0 to avoid warning about nans
+    d_prime = Z(hit_rate.fillna(0)) - Z(fa_rate.fillna(0))
+
+    # for every location in hit_rate and fa_rate with a nan, fill d_prime with a nan
+    for nan_locs in [hit_rate_nan_locs, fa_rate_nan_locs]:
+        d_prime[nan_locs] = np.nan
+
+    if len(d_prime) == 1:
+        # if the result is a 1-length vector, return as a scalar
+        return d_prime[0]
+    else:
+        return d_prime
+
+
+def response_probabilities_trial_number_limit(P, N):
+    '''
+    Calculates limits on response probability estimate based on trial count.
+    An important point to note about d' is that the metric will be infinite with
+    perfect performance, given that Z(0) = -infinity and Z(1) = infinity.
+    Low trial counts exacerbate this issue. For example, with only one sample of a go-trial,
+    the hit rate will either be 1 or 0. Macmillan and Creelman [1] offer a correction on the hit and false
+    alarm rates to avoid infinite values whereby the response probabilities (P) are bounded by
+    functions of the trial count, N:
+
+        1/(2N) < P < 1 - 1/(2N)
+
+    Thus, for the example of just a single trial, the trial-corrected hit rate would be 0.5.
+    Or after only two trials, the hit rate could take on the values of 0.25, 0.5, or 0.75.
+
+    [1] Macmillan, Neil A., and C. Douglas Creelman. Detection theory: A user's guide. Psychology press, 2004.
+    Parameters
+    ----------
+    P : float
+        response probability, bounded by 0 and 1
+    N : int
+        number of trials used in the response probability calculation
+
+    Returns
+    -------
+    P_corrected : float
+        The response probability after adjusting for the trial count
+
+    Examples
+    --------
+    Passing in a response probability of 1 and trial count of 10 will lead to a reduced
+    estimate of the response probability:
+
+    >>> trial_number_limit(1, 10)
+    0.95
+
+    A higher trial count increases the bounds on the estimate:
+
+    >>> trial_number_limit(1, 50)
+    0.99
+
+    At the limit, the bounds are 0 and 1:
+
+    >>> trial_number_limit(1, np.inf)
+    1.0
+
+    The bounds apply for estimates near 0 also:
+
+    >>> trial_number_limit(0, 1)
+    0.5
+
+    >>> trial_number_limit(0, 2)
+    0.25
+
+    >>> trial_number_limit(0, 3)
+    0.16666666666666666
+
+    Note that passing a probality that is inside of the bounds
+    results in no change to the passed probability:
+
+    >>> trial_number_limit(0.25, 3)
+    0.25
+    '''
+    if N == 0:
+        return np.nan
+    if not pd.isnull(P):
+        P = np.max((P, 1. / (2 * N)))
+        P = np.min((P, 1 - 1. / (2 * N)))
+    return P

--- a/mindscope_utilities/general_utilities.py
+++ b/mindscope_utilities/general_utilities.py
@@ -298,7 +298,7 @@ def event_triggered_response(data, t, y, event_times, t_start=None, t_end=None, 
     assert t_after is None or t_end is None, 'cannot pass both t_after and t_end'  # noqa: E501
 
     if interpolate is False:
-        assert output_sampling_rate is None, 'if interpolation = False, the sampling rate of the input timeseries will be used. Do not specify output_sampling_rate' # NOQA E501
+        assert output_sampling_rate is None, 'if interpolation = False, the sampling rate of the input timeseries will be used. Do not specify output_sampling_rate'  # NOQA E501
 
     # assign time values to t_start and t_end
     if t_start is None:
@@ -397,6 +397,7 @@ def event_triggered_response(data, t, y, event_times, t_start=None, t_end=None, 
         )
         # return the tidy event triggered responses
         return tidy_etr
+
 
 def dprime(hit_rate=None, fa_rate=None, go_trials=None, catch_trials=None, limits=False):
     '''
@@ -509,8 +510,10 @@ def dprime(hit_rate=None, fa_rate=None, go_trials=None, catch_trials=None, limit
     assert hit_rate is None or go_trials is None, 'do not pass both `hit_rate` and a boolean vector of `go_trials`'
     assert fa_rate is None or catch_trials is None, 'do not pass both `fa_rate` and a boolean vector of `catch_trials`'
 
-    assert not (hit_rate is not None and limits == True), 'limits can only be calculated if a go_trials vector is passed, not a hit_rate'
-    assert not (fa_rate is not None and limits == True), 'limits can only be calculated if a catch_trials vector is passed, not a fa_rate'
+    assert not (hit_rate is not None and limits ==
+                True), 'limits can only be calculated if a go_trials vector is passed, not a hit_rate'
+    assert not (fa_rate is not None and limits ==
+                True), 'limits can only be calculated if a catch_trials vector is passed, not a fa_rate'
 
     # calculate hit and fa rates as mean of boolean vectors
     if hit_rate is None:
@@ -525,8 +528,10 @@ def dprime(hit_rate=None, fa_rate=None, go_trials=None, catch_trials=None, limit
         limits = (0.01, 0.99)
     elif limits == True:
         # clip the hit and fa rate based on trial count
-        hit_rate = response_probabilities_trial_number_limit(hit_rate, len(go_trials))
-        fa_rate = response_probabilities_trial_number_limit(fa_rate, len(catch_trials))
+        hit_rate = response_probabilities_trial_number_limit(
+            hit_rate, len(go_trials))
+        fa_rate = response_probabilities_trial_number_limit(
+            fa_rate, len(catch_trials))
 
     if limits != True:
         # Limit values in order to avoid d' infinity

--- a/mindscope_utilities/general_utilities.py
+++ b/mindscope_utilities/general_utilities.py
@@ -510,10 +510,8 @@ def dprime(hit_rate=None, fa_rate=None, go_trials=None, catch_trials=None, limit
     assert hit_rate is None or go_trials is None, 'do not pass both `hit_rate` and a boolean vector of `go_trials`'
     assert fa_rate is None or catch_trials is None, 'do not pass both `fa_rate` and a boolean vector of `catch_trials`'
 
-    assert not (hit_rate is not None and limits ==
-                True), 'limits can only be calculated if a go_trials vector is passed, not a hit_rate'
-    assert not (fa_rate is not None and limits ==
-                True), 'limits can only be calculated if a catch_trials vector is passed, not a fa_rate'
+    assert not (hit_rate is not None and limits is True), 'limits can only be calculated if a go_trials vector is passed, not a hit_rate'
+    assert not (fa_rate is not None and limits is True), 'limits can only be calculated if a catch_trials vector is passed, not a fa_rate'
 
     # calculate hit and fa rates as mean of boolean vectors
     if hit_rate is None:
@@ -523,17 +521,17 @@ def dprime(hit_rate=None, fa_rate=None, go_trials=None, catch_trials=None, limit
 
     Z = norm.ppf
 
-    if limits == False:
+    if limits is False:
         # if limits are False, apply default
         limits = (0.01, 0.99)
-    elif limits == True:
+    elif limits is True:
         # clip the hit and fa rate based on trial count
         hit_rate = response_probabilities_trial_number_limit(
             hit_rate, len(go_trials))
         fa_rate = response_probabilities_trial_number_limit(
             fa_rate, len(catch_trials))
 
-    if limits != True:
+    if limits is not True:
         # Limit values in order to avoid d' infinity
         hit_rate = np.clip(hit_rate, limits[0], limits[1])
         fa_rate = np.clip(fa_rate, limits[0], limits[1])

--- a/mindscope_utilities/visual_behavior_ophys/__init__.py
+++ b/mindscope_utilities/visual_behavior_ophys/__init__.py
@@ -1,1 +1,2 @@
 from .data_formatting import *  # noqa: F401,F403
+from .plotting_utilities import *  # noqa: F401,F403

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -620,6 +620,121 @@ def add_reward_rate_to_stimulus_presentations_df(trials_df, stimulus_presentatio
     return stimulus_presentations_df
 
 
+def annotate_stimuli(dataset, inplace=False):
+    '''
+    adds the following columns to the stimulus_presentations table, facilitating calculation
+    of behavior performance based entirely on the stimulus_presentations table:
+
+    'trials_id': the corresponding ID of the trial in the trials table in which the stimulus occurred
+    'previous_image_name': the name of the stimulus on the last flash (will list 'omitted' if last stimulus is omitted)
+    'next_start_time': The time of the next stimulus start (including the time of the omitted stimulus if the next stimulus is omitted)
+    'auto_rewarded': True for trials where rewards were delivered regardless of animal response
+    'trial_stimulus_index': index of the given stimulus on the current trial. For example, the first stimulus in a trial has index 0, the second stimulus in a trial has index 1, etc
+    'response_lick': Boolean, True if a lick followed the stimulus
+    'response_lick_times': list of all lick times following this stimulus
+    'response_lick_latency': time difference between first lick and stimulus
+    'previous_response_on_trial': Boolean, True if there has been a lick to a previous stimulus on this trial
+    'could_change': Boolean, True if the stimulus met the conditions that would have allowed
+                    to be chosen as the change stimulus by camstim:
+                        * at least the fourth stimulus flash in the trial
+                        * not preceded by any licks on that trial
+
+    Parameters:
+    -----------
+    dataset : BehaviorSession or BehaviorOphysSession object
+        an SDK session object
+    inplace : Boolean
+        If True, operates on the dataset.stimulus_presentations object directly and returns None
+        If False (default), operates on a copy and returns the copy
+
+    Returns:
+    --------
+    Pandas.DataFrame (if inplace == False)
+    None (if inplace == True)
+    '''
+
+    if inplace:
+        stimulus_presentations = dataset.stimulus_presentations
+    else:
+        stimulus_presentations = dataset.stimulus_presentations.copy()
+
+    # add previous_image_name
+    stimulus_presentations['previous_image_name'] = stimulus_presentations['image_name'].shift()
+
+    # add next_start_time
+    stimulus_presentations['next_start_time'] = stimulus_presentations['start_time'].shift(-1)
+
+    # add trials_id and trial_stimulus_index
+    stimulus_presentations['trials_id'] = None
+    stimulus_presentations['trial_stimulus_index'] = None
+    last_trial_id = -1
+    trial_stimulus_index = 0
+
+    # add response_lick, response_lick_times, response_lick_latency
+    stimulus_presentations['response_lick'] = False
+    stimulus_presentations['response_lick_times'] = None
+    stimulus_presentations['response_lick_latency'] = None
+
+    # make a copy of trials with 'start_time' as index to speed lookup
+    trials = dataset.trials.copy().reset_index().set_index('start_time')
+
+    # make a copy of licks with 'timestamps' as index to speed lookup
+    licks = dataset.licks.copy().reset_index().set_index('timestamps')
+
+    # iterate over every stimulus
+    for idx, row in stimulus_presentations.iterrows():
+        # trials_id is last trials_id with start_time <= stimulus_time
+        try:
+            trials_id = trials.loc[:row['start_time']].iloc[-1]['trials_id']
+        except IndexError:
+            trials_id = -1
+        stimulus_presentations.at[idx, 'trials_id'] = trials_id
+
+        if trials_id == last_trial_id:
+            trial_stimulus_index += 1
+        else:
+            trial_stimulus_index = 0
+            last_trial_id = trials_id
+        stimulus_presentations.at[idx, 'trial_stimulus_index'] = trial_stimulus_index
+
+        stim_licks = licks.loc[row['start_time']:row['next_start_time'] - 1e-9].index.to_list()  # note the `- 1e-9` acts as a <, as opposed to a <=
+
+        stimulus_presentations.at[idx, 'response_lick_times'] = stim_licks
+        if len(stim_licks) > 0:
+            stimulus_presentations.at[idx, 'response_lick'] = True
+            stimulus_presentations.at[idx, 'response_lick_latency'] = stim_licks[0] - row['start_time']
+
+    # merge in auto_rewarded column from trials table
+    stimulus_presentations = stimulus_presentations.reset_index().merge(
+        dataset.trials[['auto_rewarded']],
+        on='trials_id',
+        how='left',
+    ).set_index('stimulus_presentations_id')
+
+    # add previous_response_on_trial
+    stimulus_presentations['previous_response_on_trial'] = False
+    # set 'stimulus_presentations_id' and 'trials_id' as indices to speed lookup
+    stimulus_presentations = stimulus_presentations.reset_index().set_index(['stimulus_presentations_id', 'trials_id'])
+    for idx, row in stimulus_presentations.iterrows():
+        stim_id, trials_id = idx
+        # get all stimuli before the current on the current trial
+        mask = (stimulus_presentations.index.get_level_values(0) < stim_id) & (stimulus_presentations.index.get_level_values(1) == trials_id)
+        # check to see if any previous stimuli have a response lick
+        stimulus_presentations.at[idx, 'previous_response_on_trial'] = stimulus_presentations[mask]['response_lick'].any()
+    # set the index back to being just 'stimulus_presentations_id'
+    stimulus_presentations = stimulus_presentations.reset_index().set_index('stimulus_presentations_id')
+
+    # add could_change
+    stimulus_presentations['could_change'] = False
+    for idx, row in stimulus_presentations.iterrows():
+        # check if we meet conditions where a change could occur on this stimulus (at least 4th flash of trial, no previous change on trial)
+        if row['trial_stimulus_index'] >= 4 and row['previous_response_on_trial'] == False and row['image_name'] != 'omitted' and row['previous_image_name'] != 'omitted':
+            stimulus_presentations.at[idx, 'could_change'] = True
+
+    if inplace == False:
+        return stimulus_presentations
+
+
 def calculate_response_matrix(stimuli, aggfunc=np.mean, sort_by_column=True, engaged_only=True):
     '''
     calculates the response matrix for each individual image pair in the `stimulus` dataframe
@@ -627,9 +742,8 @@ def calculate_response_matrix(stimuli, aggfunc=np.mean, sort_by_column=True, eng
     Parameters:
     -----------
     stimuli: Pandas.DataFrame
-        From experiment.stimulus_presentations, after adding engagement state and annotating as follows:
-            experiment.stimulus_presentations = loading.add_model_outputs_to_stimulus_presentations(experiment.stimulus_presentations, behavior_session_id')
-            stimulus_presentations = vbu.annotate_stimuli(experiment, inplace = False)
+        From experiment.stimulus_presentations, after annotating as follows:
+            annotate_stimuli(experiment, inplace = True)
     aggfunc: function
         function to apply to calculation. Default = np.mean
         other options include np.size (to get counts) or np.median
@@ -637,6 +751,7 @@ def calculate_response_matrix(stimuli, aggfunc=np.mean, sort_by_column=True, eng
         if True (default), sorts outputs by column means
     engaged_only: Boolean
         If True (default), calculates only on engaged trials
+        Will throw an assertion error if True and 'engagement_state' column does not exist
 
     Returns:
     --------
@@ -649,6 +764,7 @@ def calculate_response_matrix(stimuli, aggfunc=np.mean, sort_by_column=True, eng
     '''
     stimuli_to_analyze = stimuli.query('auto_rewarded == False and could_change == True and image_name != "omitted" and previous_image_name != "omitted"')
     if engaged_only:
+        assert 'engagement_state' in stimuli_to_analyze.columns, 'stimuli must have column called "engagement_state" if passing engaged_only = True'
         stimuli_to_analyze = stimuli_to_analyze.query('engagement_state == "engaged"')
 
     response_matrix = pd.pivot_table(
@@ -668,20 +784,20 @@ def calculate_response_matrix(stimuli, aggfunc=np.mean, sort_by_column=True, eng
     return response_matrix
 
 
-def calculate_d_prime_matrix(stimuli, sort_by_column=True, engaged_only=True):
+def calculate_dprime_matrix(stimuli, sort_by_column=True, engaged_only=True):
     '''
     calculates the d' matrix for each individual image pair in the `stimulus` dataframe
 
     Parameters:
     -----------
     stimuli: Pandas.DataFrame
-        From experiment.stimulus_presentations, after adding engagement state and annotating as follows:
-            experiment.stimulus_presentations = loading.add_model_outputs_to_stimulus_presentations(experiment.stimulus_presentations, behavior_session_id')
-            stimulus_presentations = vbu.annotate_stimuli(experiment, inplace = False)
+        From experiment.stimulus_presentations, after annotating as follows:
+            annotate_stimuli(experiment, inplace = True)
     sort_by_column: Boolean
         if True (default), sorts outputs by column means
     engaged_only: Boolean
         If True (default), calculates only on engaged trials
+        Will throw an assertion error if True and 'engagement_state' column does not exist
 
     Returns:
     --------
@@ -692,12 +808,15 @@ def calculate_d_prime_matrix(stimuli, sort_by_column=True, engaged_only=True):
         catch trials are on diagonal
 
     '''
+    if engaged_only:
+        assert 'engagement_state' in stimuli.columns, 'stimuli must have column called "engagement_state" if passing engaged_only = True'
+    
     response_matrix = calculate_response_matrix(stimuli, aggfunc=np.mean, sort_by_column=sort_by_column, engaged_only=engaged_only)
 
     d_prime_matrix = response_matrix.copy()
     for row in response_matrix.columns:
         for col in response_matrix.columns:
-            d_prime_matrix.loc[row][col] = vbu.dprime(
+            d_prime_matrix.loc[row][col] = mindscope_utilities.dprime(
                 hit_rate=response_matrix.loc[row][col],
                 fa_rate=response_matrix[col][col],
                 limits=False

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -76,7 +76,7 @@ def build_tidy_cell_df(ophys_experiment, exclude_invalid_rois=True):
 
 
 def get_event_timestamps(
-        stimulus_presentations_df,
+        stimulus_presentation,
         event_type='all',
         onset='start_time'):
     '''
@@ -84,14 +84,14 @@ def get_event_timestamps(
 
     Parameters:
     ___________
-    stimulus_presentations_df: Pandas.DataFrame
+    stimulus_presentation: Pandas.DataFrame
         Output of stimulus_presentations with stimulus trial metadata
     event_type: str
-        Event of interest. Event_type can be any column in the stimulus_presentations_df,  # noqa E501
+        Event of interest. Event_type can be any column in the stimulus_presentation,  # noqa E501
         including 'omissions' or 'change'. Default is 'all', gets all trials  # noqa E501
     onset: str
         optons: 'start_time' - onset of the stimulus, 'stop_time' - offset of the stimulus
-        stimulus_presentations_df has a multiple timestamps to align data to. Default = 'start_time'.
+        stimulus_presentation has a multiple timestamps to align data to. Default = 'start_time'.
 
     Returns:
         event_times: array
@@ -99,20 +99,20 @@ def get_event_timestamps(
     --------
     '''
     if event_type == 'all':
-        event_times = stimulus_presentations_df[onset]
-        event_ids = stimulus_presentations_df.index.values
+        event_times = stimulus_presentation[onset]
+        event_ids = stimulus_presentation.index.values
     elif event_type == 'images':
-        event_times = stimulus_presentations_df[stimulus_presentations_df['omitted'] == False][onset]  # noqa E501
-        event_ids = stimulus_presentations_df[stimulus_presentations_df['omitted'] == False].index.values  # noqa E501
+        event_times = stimulus_presentation[stimulus_presentation['omitted'] == False][onset]  # noqa E501
+        event_ids = stimulus_presentation[stimulus_presentation['omitted'] == False].index.values  # noqa E501
     elif event_type == 'omissions' or event_type == 'omitted':
-        event_times = stimulus_presentations_df[stimulus_presentations_df['omitted']][onset]  # noqa E501
-        event_ids = stimulus_presentations_df[stimulus_presentations_df['omitted']].index.values  # noqa E501
+        event_times = stimulus_presentation[stimulus_presentation['omitted']][onset]  # noqa E501
+        event_ids = stimulus_presentation[stimulus_presentation['omitted']].index.values  # noqa E501
     elif event_type == 'changes' or event_type == 'is_change':
-        event_times = stimulus_presentations_df[stimulus_presentations_df['is_change']][onset]  # noqa E501
-        event_ids = stimulus_presentations_df[stimulus_presentations_df['is_change']].index.values  # noqa E501
+        event_times = stimulus_presentation[stimulus_presentation['is_change']][onset]  # noqa E501
+        event_ids = stimulus_presentation[stimulus_presentation['is_change']].index.values  # noqa E501
     else:
-        event_times = stimulus_presentations_df[stimulus_presentations_df[event_type]][onset]  # noqa E501
-        event_ids = stimulus_presentations_df[stimulus_presentations_df[event_type]].index.values  # noqa E501
+        event_times = stimulus_presentation[stimulus_presentation[event_type]][onset]  # noqa E501
+        event_ids = stimulus_presentation[stimulus_presentation[event_type]].index.values  # noqa E501
 
     return event_times, event_ids
 
@@ -163,11 +163,11 @@ def get_stimulus_response_xr(ophys_experiment,
     neural_data = build_tidy_cell_df(ophys_experiment)
 
     # load stimulus_presentations table
-    stimulus_presentations_df = ophys_experiment.stimulus_presentations
+    stimulus_presentation = ophys_experiment.stimulus_presentations
 
     # get event times and event ids (original order in the stimulus flow)
     event_times, event_ids = get_event_timestamps(
-        stimulus_presentations_df, event_type)
+        stimulus_presentation, event_type)
 
     # all cell specimen ids in an ophys_experiment
     cell_ids = np.unique(neural_data['cell_specimen_id'].values)
@@ -592,12 +592,12 @@ def add_reward_rate_to_stimulus_presentations(trials, stimulus_presentations):
     ____________
     trials_df: Pandas.DataFrame
         ophys_experiment.trials
-    stimulus_presentations_df: Pandas.DataFrame
+    stimulus_presentation: Pandas.DataFrame
         ophys_experiment.stimulus_presentations
 
     Returns:
     ___________
-    stimulus_presentations_df: Pandas.DataFrame
+    stimulus_presentation: Pandas.DataFrame
         with 'reward_rate' column
     '''
 
@@ -618,8 +618,8 @@ def add_reward_rate_to_stimulus_presentations(trials, stimulus_presentations):
     for i in range(len(stimulus_presentations) - len(reward_rate_by_frame)):
         reward_rate_by_frame.append(reward_rate_by_frame[-1])
 
-    stimulus_presentations_df['reward_rate'] = reward_rate_by_frame
-    return stimulus_presentations_df
+    stimulus_presentation['reward_rate'] = reward_rate_by_frame
+    return stimulus_presentation
 
 
 def annotate_stimuli(dataset, inplace=False):

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -91,7 +91,7 @@ def get_event_timestamps(
         including 'omissions' or 'change'. Default is 'all', gets all trials  # noqa E501
     onset: str
         optons: 'start_time' - onset of the stimulus, 'stop_time' - offset of the stimulus
-        stimulus_presentation has a multiple timestamps to align data to. Default = 'start_time'.
+        stimulus_presentationshas a multiple timestamps to align data to. Default = 'start_time'.
 
     Returns:
         event_times: array
@@ -163,7 +163,7 @@ def get_stimulus_response_xr(ophys_experiment,
     neural_data = build_tidy_cell_df(ophys_experiment)
 
     # load stimulus_presentations table
-    stimulus_presentation = ophys_experiment.stimulus_presentations
+    stimulus_presentations= ophys_experiment.stimulus_presentations
 
     # get event times and event ids (original order in the stimulus flow)
     event_times, event_ids = get_event_timestamps(

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -547,12 +547,7 @@ def add_mean_running_speed_to_stimulus_presentations(
     return stimulus_presentations
 
 
-def add_mean_pupil_area_to_stimulus_presentations(
-    stimulus_presentations,
-    eye_tracking,
-    time_window=[
-        -3,
-        3]):
+def add_mean_pupil_area_to_stimulus_presentations(stimulus_presentations, eye_tracking, time_window=[-3, 3]):
     '''
     Append a column to stimulus_presentations which contains
     the mean pupil area in a range relative to
@@ -630,3 +625,91 @@ def add_reward_rate_to_stimulus_presentations_df(trials_df, stimulus_presentatio
         reward_rate_by_frame.append(reward_rate_by_frame[-1])
     stimulus_presentations_df['reward_rate'] = reward_rate_by_frame
     return stimulus_presentations_df
+
+
+def calculate_response_matrix(stimuli, aggfunc=np.mean, sort_by_column=True, engaged_only=True):
+    '''
+    calculates the response matrix for each individual image pair in the `stimulus` dataframe
+
+    Parameters:
+    -----------
+    stimuli: Pandas.DataFrame
+        From experiment.stimulus_presentations, after adding engagement state and annotating as follows:
+            experiment.stimulus_presentations = loading.add_model_outputs_to_stimulus_presentations(experiment.stimulus_presentations, behavior_session_id')
+            stimulus_presentations = vbu.annotate_stimuli(experiment, inplace = False)
+    aggfunc: function
+        function to apply to calculation. Default = np.mean
+        other options include np.size (to get counts) or np.median
+    sort_by_column: Boolean
+        if True (default), sorts outputs by column means
+    engaged_only: Boolean
+        If True (default), calculates only on engaged trials
+
+    Returns:
+    --------
+    Pandas.DataFrame
+        matrix of response probabilities for each image combination
+        index = previous image
+        column = current image
+        catch trials are on diagonal
+
+    '''
+    stimuli_to_analyze = stimuli.query('auto_rewarded == False and could_change == True and image_name != "omitted" and previous_image_name != "omitted"')
+    if engaged_only:
+        stimuli_to_analyze = stimuli_to_analyze.query('engagement_state == "engaged"')
+
+    response_matrix = pd.pivot_table(
+        stimuli_to_analyze,
+        values='response_lick',
+        index=['previous_image_name'],
+        columns=['image_name'],
+        aggfunc=aggfunc
+    ).astype(float)
+
+    if sort_by_column:
+        sort_by = response_matrix.mean(axis=0).sort_values().index
+        response_matrix = response_matrix.loc[sort_by][sort_by]
+
+    response_matrix.index.name = 'previous_image_name'
+
+    return response_matrix
+
+
+def calculate_d_prime_matrix(stimuli, sort_by_column=True, engaged_only=True):
+    '''
+    calculates the d' matrix for each individual image pair in the `stimulus` dataframe
+
+    Parameters:
+    -----------
+    stimuli: Pandas.DataFrame
+        From experiment.stimulus_presentations, after adding engagement state and annotating as follows:
+            experiment.stimulus_presentations = loading.add_model_outputs_to_stimulus_presentations(experiment.stimulus_presentations, behavior_session_id')
+            stimulus_presentations = vbu.annotate_stimuli(experiment, inplace = False)
+    sort_by_column: Boolean
+        if True (default), sorts outputs by column means
+    engaged_only: Boolean
+        If True (default), calculates only on engaged trials
+
+    Returns:
+    --------
+    Pandas.DataFrame
+        matrix of d' for each image combination
+        index = previous image
+        column = current image
+        catch trials are on diagonal
+
+    '''
+    response_matrix = calculate_response_matrix(stimuli, aggfunc=np.mean, sort_by_column=sort_by_column, engaged_only=engaged_only)
+
+    d_prime_matrix = response_matrix.copy()
+    for row in response_matrix.columns:
+        for col in response_matrix.columns:
+            d_prime_matrix.loc[row][col] = vbu.dprime(
+                hit_rate=response_matrix.loc[row][col],
+                fa_rate=response_matrix[col][col],
+                limits=False
+            )
+            if row == col:
+                d_prime_matrix.loc[row][col] = np.nan
+
+    return d_prime_matrix

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -728,10 +728,10 @@ def annotate_stimuli(dataset, inplace=False):
     stimulus_presentations['could_change'] = False
     for idx, row in stimulus_presentations.iterrows():
         # check if we meet conditions where a change could occur on this stimulus (at least 4th flash of trial, no previous change on trial)
-        if row['trial_stimulus_index'] >= 4 and row['previous_response_on_trial'] == False and row['image_name'] != 'omitted' and row['previous_image_name'] != 'omitted':
+        if row['trial_stimulus_index'] >= 4 and row['previous_response_on_trial'] is False and row['image_name'] != 'omitted' and row['previous_image_name'] != 'omitted':
             stimulus_presentations.at[idx, 'could_change'] = True
 
-    if inplace == False:
+    if inplace is False:
         return stimulus_presentations
 
 
@@ -810,7 +810,7 @@ def calculate_dprime_matrix(stimuli, sort_by_column=True, engaged_only=True):
     '''
     if engaged_only:
         assert 'engagement_state' in stimuli.columns, 'stimuli must have column called "engagement_state" if passing engaged_only = True'
-    
+
     response_matrix = calculate_response_matrix(stimuli, aggfunc=np.mean, sort_by_column=sort_by_column, engaged_only=engaged_only)
 
     d_prime_matrix = response_matrix.copy()

--- a/mindscope_utilities/visual_behavior_ophys/plotting_utilities.py
+++ b/mindscope_utilities/visual_behavior_ophys/plotting_utilities.py
@@ -2,13 +2,13 @@ import matplotlib.pyplot as plt
 from mindscope_utilities.visual_behavior_ophys import calculate_response_matrix, calculate_dprime_matrix
 
 
-def plot_response_matrix(stimuli, ax=None, vmin=0, vmax=1, cmap='viridis', cbar_ax=None):
+def plot_response_matrix(stimulus_presentations, ax=None, vmin=0, vmax=1, cmap='viridis', cbar_ax=None):
     '''
     makes a plot of the response matrix given a table of stimuli
 
     Parameters:
     -----------
-    stimuli : pandas.dataframe
+    stimulus_presentations : pandas.dataframe
         From experiment.stimulus_presentations, after annotating as follows:
             annotate_stimuli(experiment, inplace = True)
     ax : matplotlib axis
@@ -35,7 +35,7 @@ def plot_response_matrix(stimuli, ax=None, vmin=0, vmax=1, cmap='viridis', cbar_
         return_fig_ax = True
         fig, ax = plt.subplots()
 
-    response_matrix = calculate_response_matrix(stimuli)
+    response_matrix = calculate_response_matrix(stimulus_presentations)
 
     im = ax.imshow(
         response_matrix,
@@ -58,14 +58,14 @@ def plot_response_matrix(stimuli, ax=None, vmin=0, vmax=1, cmap='viridis', cbar_
         return fig, ax
 
 
-def plot_dprime_matrix(stimuli, ax=None, vmin=0, vmax=1.5, cmap='magma', cbar_ax=None):
+def plot_dprime_matrix(stimulus_presentations, ax=None, vmin=0, vmax=1.5, cmap='magma', cbar_ax=None):
     '''
     makes a plot of the response matrix given a table of stimuli
     Parameters:
     -----------
-    stimuli : pandas.dataframe
+    stimulus_presentations : pandas.dataframe
         From experiment.stimulus_presentations, after annotating as follows:
-            annotate_stimuli(experiment, inplace = True)
+            annotate_stimulus_presentations(experiment, inplace = True)
     ax : matplotlib axis
         axis on which to plot.
         If not passed, will create a figure and axis and return both
@@ -90,7 +90,7 @@ def plot_dprime_matrix(stimuli, ax=None, vmin=0, vmax=1.5, cmap='magma', cbar_ax
         return_fig_ax = True
         fig, ax = plt.subplots()
 
-    dprime_matrix = calculate_dprime_matrix(stimuli)
+    dprime_matrix = calculate_dprime_matrix(stimulus_presentations)
 
     im = ax.imshow(
         dprime_matrix,

--- a/mindscope_utilities/visual_behavior_ophys/plotting_utilities.py
+++ b/mindscope_utilities/visual_behavior_ophys/plotting_utilities.py
@@ -1,12 +1,35 @@
 import matplotlib.pyplot as plt
-import seaborn as sns
 from mindscope_utilities.visual_behavior_ophys import calculate_response_matrix, calculate_dprime_matrix
+
 
 def plot_response_matrix(stimuli, ax=None, vmin=0, vmax=1, cmap='viridis', cbar_ax=None):
     '''
     makes a plot of the response matrix given a table of stimuli
+
+    Parameters:
+    -----------
+    stimuli : pandas.dataframe
+        From experiment.stimulus_presentations, after annotating as follows:
+            annotate_stimuli(experiment, inplace = True)
+    ax : matplotlib axis
+        axis on which to plot.
+        If not passed, will create a figure and axis and return both
+    vmin : float
+        minimum for plot, default = 0
+    vmax : float
+        maximum for plot, default = 1
+    cmap : string
+        cmap for plot, default = 'viridis'
+    cbar_ax : matplotlib axis
+        axis on which to plot colorbar
+        colorbar will not be added if not passed
+
+    Returns:
+    --------
+    fig, ax if ax is not passed
+    None if ax is passed
     '''
-    
+
     return_fig_ax = False
     if ax is None:
         return_fig_ax = True
@@ -38,6 +61,28 @@ def plot_response_matrix(stimuli, ax=None, vmin=0, vmax=1, cmap='viridis', cbar_
 def plot_dprime_matrix(stimuli, ax=None, vmin=0, vmax=1.5, cmap='magma', cbar_ax=None):
     '''
     makes a plot of the response matrix given a table of stimuli
+    Parameters:
+    -----------
+    stimuli : pandas.dataframe
+        From experiment.stimulus_presentations, after annotating as follows:
+            annotate_stimuli(experiment, inplace = True)
+    ax : matplotlib axis
+        axis on which to plot.
+        If not passed, will create a figure and axis and return both
+    vmin : float
+        minimum for plot, default = 0
+    vmax : float
+        maximum for plot, default = 1.5
+    cmap : string
+        cmap for plot, default = 'magma'
+    cbar_ax : matplotlib axis
+        axis on which to plot colorbar
+        colorbar will not be added if not passed
+
+    Returns:
+    --------
+    fig, ax if ax is not passed
+    None if ax is passed
     '''
 
     return_fig_ax = False

--- a/mindscope_utilities/visual_behavior_ophys/plotting_utilities.py
+++ b/mindscope_utilities/visual_behavior_ophys/plotting_utilities.py
@@ -1,0 +1,25 @@
+import matplotlib.pyplot as plt
+import seaborn as sns
+from mindscope_utilities.visual_behavior.ophys import calculate_response_matrix, calculate_d_prime_matrix
+
+def plot_response_matrix(stimuli, ax=None, cmap='viridis'):
+    
+    return_fig_ax = False
+    if ax is None:
+        return return_fig_ax = True
+        fig, ax = plt.subplots()
+
+    response_matrix = make_response_matrix(stimuli)
+
+    sns.heatmap(
+        response_matrix,
+        ax=ax[0, ii],
+        cmap='viridis',
+        vmin=0,
+        vmax=1,
+#         cbar=cbar,
+#         annot=annotate, 
+#         annot_kws=akws,
+#         fmt=annot_format,
+        square=True
+    )

--- a/mindscope_utilities/visual_behavior_ophys/plotting_utilities.py
+++ b/mindscope_utilities/visual_behavior_ophys/plotting_utilities.py
@@ -1,25 +1,68 @@
 import matplotlib.pyplot as plt
 import seaborn as sns
-from mindscope_utilities.visual_behavior.ophys import calculate_response_matrix, calculate_d_prime_matrix
+from mindscope_utilities.visual_behavior_ophys import calculate_response_matrix, calculate_dprime_matrix
 
-def plot_response_matrix(stimuli, ax=None, cmap='viridis'):
+def plot_response_matrix(stimuli, ax=None, vmin=0, vmax=1, cmap='viridis', cbar_ax=None):
+    '''
+    makes a plot of the response matrix given a table of stimuli
+    '''
     
     return_fig_ax = False
     if ax is None:
-        return return_fig_ax = True
+        return_fig_ax = True
         fig, ax = plt.subplots()
 
-    response_matrix = make_response_matrix(stimuli)
+    response_matrix = calculate_response_matrix(stimuli)
 
-    sns.heatmap(
+    im = ax.imshow(
         response_matrix,
-        ax=ax[0, ii],
-        cmap='viridis',
-        vmin=0,
-        vmax=1,
-#         cbar=cbar,
-#         annot=annotate, 
-#         annot_kws=akws,
-#         fmt=annot_format,
-        square=True
+        cmap=cmap,
+        aspect='equal',
+        vmin=vmin,
+        vmax=vmax,
     )
+    ax.set_xticks(range(len(response_matrix)))
+    ax.set_xticklabels(response_matrix.columns)
+    ax.set_yticks(range(len(response_matrix)))
+    ax.set_yticklabels(response_matrix.index)
+    ax.set_xlabel('image name')
+    ax.set_ylabel('previous image name')
+
+    if cbar_ax is not None:
+        plt.colorbar(im, cax=cbar_ax, label='response probability')
+
+    if return_fig_ax:
+        return fig, ax
+
+
+def plot_dprime_matrix(stimuli, ax=None, vmin=0, vmax=1.5, cmap='magma', cbar_ax=None):
+    '''
+    makes a plot of the response matrix given a table of stimuli
+    '''
+
+    return_fig_ax = False
+    if ax is None:
+        return_fig_ax = True
+        fig, ax = plt.subplots()
+
+    dprime_matrix = calculate_dprime_matrix(stimuli)
+
+    im = ax.imshow(
+        dprime_matrix,
+        cmap=cmap,
+        aspect='equal',
+        vmin=vmin,
+        vmax=vmax,
+    )
+    ax.set_xticks(range(len(dprime_matrix)))
+    ax.set_xticklabels(dprime_matrix.columns)
+    ax.set_yticks(range(len(dprime_matrix)))
+    ax.set_yticklabels(dprime_matrix.index)
+    ax.set_xlabel('image name')
+    ax.set_ylabel('previous image name')
+
+    if cbar_ax is not None:
+        plt.colorbar(im, cax=cbar_ax, label="d'")
+
+    if return_fig_ax:
+        return fig, ax

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 import pandas as pd
 import numpy as np
 import pytest
+import os
 
 class SimulatedExperiment(object):
     '''
@@ -85,6 +86,7 @@ class SimulatedExperiment(object):
         })
         return events.set_index('cell_specimen_id')
 
+
 @pytest.fixture
 def simulated_experiment_fixture():
    # build a simulated experiment
@@ -103,3 +105,22 @@ def simulated_experiment_fixture():
         filtered_events = [np.cos(4*np.pi*timestamps+ ii*0.5*np.pi) for ii, cell in enumerate(cell_specimen_ids)]
     )
     return simulated_experiment
+
+
+@pytest.fixture
+def visual_behavior_ophys_test_experiment():
+    # get a sample experiment
+    from allensdk.brain_observatory.behavior.behavior_project_cache import VisualBehaviorOphysProjectCache
+    top_level_path = os.path.dirname(__file__)
+    for _ in range(2):
+            top_level_path = os.path.split(top_level_path)[0]
+    cache_dir = os.path.join(top_level_path, '.nwb_cache')
+    if not os.path.exists(cache_dir):
+        os.mkdir(cache_dir)
+
+    cache = VisualBehaviorOphysProjectCache.from_s3_cache(cache_dir=cache_dir)
+
+    ophys_experiment_id = 982343736
+    experiment = cache.get_behavior_ophys_experiment(ophys_experiment_id)
+
+    return experiment

--- a/tests/mindscope_utilities/test_general_utilities.py
+++ b/tests/mindscope_utilities/test_general_utilities.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from mindscope_utilities import event_triggered_response, get_time_array, index_of_nearest_value, slice_inds_and_offsets
+from mindscope_utilities import *
 
 def test_get_time_array_with_sampling_rate():
     '''
@@ -179,3 +179,51 @@ def test_event_triggered_response():
 
     # Assert that the dataframe is unchanged
     pd.testing.assert_frame_equal(df, df_copy)
+
+
+def test_response_probabilities_trial_number_limit():
+    assert response_probabilities_trial_number_limit(1, 5) == 0.9
+
+    assert response_probabilities_trial_number_limit(1, 50) == 0.99
+
+    assert response_probabilities_trial_number_limit(1, 100) == 0.995
+
+    assert response_probabilities_trial_number_limit(0.5, 100) == 0.5
+
+    assert response_probabilities_trial_number_limit(0, 100) == 0.005
+
+
+def test_dprime():
+
+    d_prime = dprime(1.0, 0.0)
+    assert d_prime == 4.6526957480816815
+
+    d_prime = dprime(1.0, 0.0, limits=False)
+    assert d_prime == 4.6526957480816815
+
+    d_prime = dprime(1.0, 0.0, limits=(0.01, 0.99))
+    assert d_prime == 4.6526957480816815
+
+    d_prime = dprime(1.0, 0.0, limits=(0.0, 1.0))
+    assert d_prime == np.inf
+
+    d_prime = dprime(
+        go_trials=[1, 1, 1, 1, 1, 1, 1],
+        catch_trials=[0, 0],
+        limits=True
+    )
+    assert d_prime == 2.1397235428816046
+
+    d_prime = dprime(
+        go_trials=[1, 1, 1, 1, 1, 1, 1],
+        catch_trials=[0, 0],
+        limits=False
+    )
+    assert d_prime == 4.6526957480816815
+
+    d_prime = dprime(
+        go_trials=[0, 1, 0, 1],
+        catch_trials=[0, 1],
+        limits=False
+    )
+    assert d_prime == 0.0

--- a/tests/mindscope_utilities/visual_behavior_ophys/test_data_formatting.py
+++ b/tests/mindscope_utilities/visual_behavior_ophys/test_data_formatting.py
@@ -38,3 +38,46 @@ def test_build_tidy_cell_df(simulated_experiment_fixture):
     actual_2 = tidy_cell_df.query('cell_specimen_id == 2 and timestamps == 0.5').reset_index(drop=True)
     pd.testing.assert_frame_equal(actual_2[cols], ans_2[cols])
 
+
+def test_annotate_stimuli(visual_behavior_ophys_test_experiment):
+    '''
+    uses `visual_behavior_ophys_test_experiment` defined in conftest.py
+    '''
+    experiment = visual_behavior_ophys_test_experiment
+
+    annotated_stimuli = visual_behavior_ophys.annotate_stimuli(experiment)
+    assert annotated_stimuli.loc[4794]['next_start_time'] == 3908.26225
+
+
+def test_calculate_response_matrix(visual_behavior_ophys_test_experiment):
+    '''
+    uses `visual_behavior_ophys_test_experiment` defined in conftest.py
+    '''
+    experiment = visual_behavior_ophys_test_experiment
+
+    annotated_stimuli = visual_behavior_ophys.annotate_stimuli(experiment)
+    rm = visual_behavior_ophys.calculate_response_matrix(
+        annotated_stimuli,
+        sort_by_column=True,
+        engaged_only=False
+    )
+
+    assert rm.loc['im106']['im106'] == 0.49411764705882355
+    assert rm.loc['im035']['im106'] == 0.5
+
+
+def test_calculate_dprime_matrix(visual_behavior_ophys_test_experiment):
+    '''
+    uses `visual_behavior_ophys_test_experiment` defined in conftest.py
+    '''
+    experiment = visual_behavior_ophys_test_experiment
+
+    annotated_stimuli = visual_behavior_ophys.annotate_stimuli(experiment)
+    dprime_matrix = visual_behavior_ophys.calculate_dprime_matrix(
+        annotated_stimuli,
+        sort_by_column=True,
+        engaged_only=False
+    )
+
+    assert dprime_matrix.loc['im035']['im106'] == 0.014745406527902915
+    assert pd.isnull(dprime_matrix.loc['im106']['im106'])


### PR DESCRIPTION
Summary of changes:
* added general_utilities.dprime, which calculates d'
* added general_utlities.response_probabilities_trial_number_limit, which calcluates trial number limits and is required by dprime
* added visual_behavior_ophys.data_formatting.annotate_stimuli, which annotates stimulus_presentations with fields necessary to calculate response probability and dprime matrices
* added visual_behavior_ophys.data_formatting.calculate_response_matrix, which calculates response matrix for a stimulus table
* added visual_behavior_ophys.data_formatting.calculate_dprime_matrix, which calculates d' matrix for a stimulus table
* added visual_behavior_ophys.plotting_utilities module
* added visual_behavior_ophys.plotting_utilities.plot_response_matrix, which plots response matrix for a stimulus table
* added visual_behavior_ophys.plotting_utilities.plot_dprime_matrix, which plots d' matrix for a stimulus table
* added a bunch of tests