### PR TITLE
updates to stimulus_response_df and annotation of stimulus_presentations

### DIFF
--- a/mindscope_utilities/general_utilities.py
+++ b/mindscope_utilities/general_utilities.py
@@ -172,7 +172,8 @@ def index_of_nearest_value(data_timestamps, event_timestamps):
     return event_indices
 
 
-def event_triggered_response(data, t, y, event_times, t_start=None, t_end=None, t_before=None, t_after=None, output_sampling_rate=None, include_endpoint=True, output_format='tidy', interpolate=True):  # NOQA E501
+def event_triggered_response(data, t, y, event_times, t_start=None, t_end=None, t_before=None, t_after=None,
+                             output_sampling_rate=None, include_endpoint=True, output_format='tidy', interpolate=True):  # NOQA E501
     '''
     Slices a timeseries relative to a given set of event times
     to build an event-triggered response.

--- a/mindscope_utilities/general_utilities.py
+++ b/mindscope_utilities/general_utilities.py
@@ -172,6 +172,22 @@ def index_of_nearest_value(data_timestamps, event_timestamps):
     return event_indices
 
 
+def eventlocked_traces(traces_array, event_indices, start_ind_offset, end_ind_offset):
+    '''
+    Extract trace for each cell, for each event-relative window.
+    Args:
+        traces_array (np.ndarray): shape (nSamples, nCells) with timeseries for each cell
+        event_indices (np.ndarray): 1-d array of shape (nEvents) with closest sample ind for each event
+        start_ind_offset (int): Where to start the window relative to each event ind
+        end_ind_offset (int): Where to end the window relative to each event ind
+    Returns:
+        sliced_dataout (np.ndarray): shape (nSamples, nEvents, nCells)
+    '''
+    all_inds = event_indices + np.arange(start_ind_offset, end_ind_offset)[:, None] # takes a slice around all event_indices
+    sliced_dataout = traces_array.T[all_inds]
+    return sliced_dataout
+
+
 def event_triggered_response(data, t, y, event_times, t_start=None, t_end=None, t_before=None, t_after=None,
                              output_sampling_rate=None, include_endpoint=True, output_format='tidy', interpolate=True):  # NOQA E501
     '''
@@ -299,7 +315,9 @@ def event_triggered_response(data, t, y, event_times, t_start=None, t_end=None, 
     assert t_after is None or t_end is None, 'cannot pass both t_after and t_end'  # noqa: E501
 
     if interpolate is False:
-        assert output_sampling_rate is None, 'if interpolation = False, the sampling rate of the input timeseries will be used. Do not specify output_sampling_rate'  # NOQA E501
+        output_sampling_rate = None
+        # MG - commenting this out because it crashes my code when interpolate = False, even if output_sampling_rate = None
+        # assert output_sampling_rate is None, 'if interpolation = False, the sampling rate of the input timeseries will be used. Do not specify output_sampling_rate'  # NOQA E501
 
     # assign time values to t_start and t_end
     if t_start is None:

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -866,7 +866,7 @@ def add_engagement_state_to_stimulus_presentations(stimulus_presentations, trial
                                             60 / .75)  # units of rewards/min
 
     reward_threshold = 2 / 3  # 2/3 rewards per minute = 1/90 rewards/second
-    stimulus_presentations['engaged'] = [x > reward_threshold for x in stimulus_presentations['reward_rate']]
+    stimulus_presentations['engaged'] = [x > reward_threshold for x in stimulus_presentations['reward_rate'].values]
     stimulus_presentations['engagement_state'] = ['engaged' if engaged == True else 'disengaged' for engaged in stimulus_presentations['engaged'].values]
 
     return stimulus_presentations

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -867,7 +867,7 @@ def add_engagement_state_to_stimulus_presentations(stimulus_presentations, trial
 
     reward_threshold = 2 / 3  # 2/3 rewards per minute = 1/90 rewards/second
     stimulus_presentations['engaged'] = [x > reward_threshold for x in stimulus_presentations['reward_rate']]
-    stimulus_presentations['engagement_state'] = ['engaged' if True else 'disengaged' for engaged in stimulus_presentations['engaged'].values]
+    stimulus_presentations['engagement_state'] = ['engaged' if engaged == True else 'disengaged' for engaged in stimulus_presentations['engaged'].values]
 
     return stimulus_presentations
 

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -524,11 +524,16 @@ def get_stimulus_response_df(ophys_experiment,
         'p_value_gray_screen': stacked_pval_gray_screen,
     })
 
-    # save frame rate as a column for reference
+    # save frame rate, time window and other metadata for reference
     if output_sampling_rate is not None:
-        stimulus_response_df['frame_rate'] = output_sampling_rate
+        stimulus_response_df['ophys_frame_rate'] = output_sampling_rate
     else:
-        stimulus_response_df['frame_rate'] = ophys_experiment.metadata['ophys_frame_rate']
+        stimulus_response_df['ophys_frame_rate'] = ophys_experiment.metadata['ophys_frame_rate']
+    stimulus_response_df['data_type'] = data_type
+    stimulus_response_df['event_type'] = event_type
+    stimulus_response_df['interpolate'] = interpolate
+    stimulus_response_df['output_sampling_rate'] = output_sampling_rate
+    stimulus_response_df['response_window_duration'] = response_window_duration
 
     return stimulus_response_df
 

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -204,6 +204,10 @@ def get_stimulus_response_xr(ophys_experiment,
         # all cell specimen ids in an ophys_experiment
         unique_ids = np.unique(data['cell_specimen_id'].values)
 
+    # get native sampling rate if one is not provided
+    if output_sampling_rate is None:
+        output_sampling_rate = 1 / np.diff(data['timestamps']).mean()
+
     # collect aligned data
     sliced_dataout = []
 
@@ -218,7 +222,7 @@ def get_stimulus_response_xr(ophys_experiment,
             t_end=time_window[1],
             output_format='wide',
             interpolate=interpolate,
-            output_sampling_rate=output_sampling_rate
+            output_sampling_rate=output_sampling_rate,
             **kwargs
         )
 

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -121,6 +121,7 @@ def get_stimulus_response_xr(ophys_experiment,
                              data_type='dff',
                              event_type='all',
                              time_window=[-3, 3],
+                             response_window_duration=0.5,
                              interpolate=True,
                              output_sampling_rate=None,
                              compute_means=True,
@@ -143,6 +144,8 @@ def get_stimulus_response_xr(ophys_experiment,
                      'changes' - get only trials of image changes
     time_window: array
         array of two int or floats indicating the time window on sliced data, default = [-3, 3]
+    response_window_duration: float
+        time period, in seconds, relative to stimulus onset to compute the mean and baseline response
     interpolate: bool
         type of alignment. If True (default) - interpolates neural data to align timestamps
         with stimulus presentations. If False - shifts data to the nearest timestamps
@@ -180,7 +183,6 @@ def get_stimulus_response_xr(ophys_experiment,
         unique_ids = [0]  # list to iterate over
     else:
         unique_id_string = 'cell_specimen_id'
-
 
     if data_type == 'running_speed':
         data = ophys_experiment.running_speed.copy() # running_speed attribute is already in tidy format
@@ -240,14 +242,14 @@ def get_stimulus_response_xr(ophys_experiment,
 
     if compute_means is True:
         stimulus_response_xr = compute_means_xr(
-            stimulus_response_xr, time_window=time_window)
+            stimulus_response_xr, response_window_duration=response_window_duration)
 
     return stimulus_response_xr
 
 
-def compute_means_xr(stimulus_response_xr, time_window):
+def compute_means_xr(stimulus_response_xr, response_window_duration=0.5):
     '''
-    Computes means of responses and spontaneous (baseline) traces.
+    Computes means of traces for stimulus response and pre-stimulus baseline.
     Response by default starts at 0, while baseline
     trace by default ends at 0.
 
@@ -257,8 +259,8 @@ def compute_means_xr(stimulus_response_xr, time_window):
         stimulus_response_xr from get_stimulus_response_xr
         with three main dimentions: cell_specimen_id,
         trail_id, and eventlocked_timestamps
-    time_window: array
-        time window in seconds, used for alignment arount events
+    response_window_duration:
+        duration in seconds relative to stimulus onset to compute the mean and baseline responses
         in get_stimulus_response_xr
 
     Returns:
@@ -266,8 +268,8 @@ def compute_means_xr(stimulus_response_xr, time_window):
         stimulus_response_xr with additional
         dimentions: mean_response and mean_baseline
     '''
-    response_range = [0, time_window[1]]
-    baseline_range = [time_window[0], 0]
+    response_range = [0, response_window_duration]
+    baseline_range = [-response_window_duration, 0]
 
     mean_response = stimulus_response_xr.loc[
         {'eventlocked_timestamps': slice(*response_range)}
@@ -290,6 +292,7 @@ def get_stimulus_response_df(ophys_experiment,
                              data_type='dff',
                              event_type='all',
                              time_window=[-3, 3],
+                             response_window_duration=0.5,
                              interpolate=True,
                              output_sampling_rate=None,
                              compute_means=True,
@@ -314,6 +317,8 @@ def get_stimulus_response_df(ophys_experiment,
                      'changes' - get only trials of image changes
     time_window: array
         array of two int or floats indicating the time window on sliced data, default = [-3, 3]
+    response_window_duration: float
+        time period, in seconds, relative to stimulus onset to compute the mean and baseline response
     interpolate: bool
         type of alignment. If True (default) - interpolates neural data to align timestamps
         with stimulus presentations. If False - shifts data to the nearest timestamps
@@ -343,6 +348,7 @@ def get_stimulus_response_df(ophys_experiment,
         data_type=data_type,
         event_type=event_type,
         time_window=time_window,
+        response_window_duration=response_window_duration,
         interpolate=interpolate,
         compute_means=compute_means,
         compute_significance=compute_significance,

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -336,7 +336,11 @@ def get_spontaneous_frames(stimulus_presentations, ophys_timestamps, gray_screen
     spont_duration = 4 * 60  # 4mins * 60sec
 
     # for spontaneous at beginning of session, get 4 minutes of gray screen values prior to first stimulus
-    behavior_start_time = stimulus_presentations.iloc[0].start_time
+    if stimulus_presentations.iloc[0].image_name == 'omitted': # something weird happens when first stimulus is omitted, start time is at beginning of session
+        first_index = 1
+    else:
+        first_index = 0
+    behavior_start_time = stimulus_presentations.iloc[first_index].start_time
     spontaneous_start_time_pre = behavior_start_time - spont_duration
     spontaneous_end_time_pre = behavior_start_time
     spontaneous_start_frame_pre = mindscope_utilities.index_of_nearest_value(ophys_timestamps, spontaneous_start_time_pre)

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -256,13 +256,18 @@ def get_stimulus_response_xr(ophys_experiment,
     # get mean response for each trial
     mean_responses = stimulus_response_xr.mean_response.data.T  # input needs to be array of nConditions, nCells
 
-    # compute significance of each trial, returns array of nConditions, nCells
-    p_value_gray_screen = get_p_value_from_shuffled_spontaneous(mean_responses,
-                                                                ophys_experiment.stimulus_presentations,
-                                                                ophys_experiment.ophys_timestamps,
-                                                                traces_array,
-                                                                response_window_duration*output_sampling_rate,
-                                                                output_sampling_rate)
+    try:
+        # compute significance of each trial, returns array of nConditions, nCells
+        p_value_gray_screen = get_p_value_from_shuffled_spontaneous(mean_responses,
+                                                                    ophys_experiment.stimulus_presentations,
+                                                                    ophys_experiment.ophys_timestamps,
+                                                                    traces_array,
+                                                                    response_window_duration*output_sampling_rate,
+                                                                    output_sampling_rate)
+    except:
+        p_value_gray_screen = np.zeros(mean_responses.shape)
+
+    print(p_value_gray_screen.shape)
 
     # put p_value_gray_screen back into same coordinates as xarray and make it an xarray data array
     p_value_gray_screen = xr.DataArray(data=p_value_gray_screen.T, coords=stimulus_response_xr.mean_response.coords)

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -920,6 +920,7 @@ def add_time_from_last_change_to_stimulus_presentations(stimulus_presentations):
 
 def get_annotated_stimulus_presentations(ophys_experiment):
     """
+    Takes in an ophys_experiment dataset object and returns the stimulus_presentations table with additional columns.
     Adds several useful columns to the stimulus_presentations table, including the mean running speed and pupil diameter for each stimulus,
     the times of licks for each stimulus, the rolling reward rate, an identifier for 10 minute epochs within a session,
     whether or not a stimulus was a pre-change or pre or post omission, and whether change stimuli were hits or misses
@@ -962,7 +963,7 @@ def get_annotated_stimulus_presentations(ophys_experiment):
 
 
 
-def annotate_stimulus_presentations_with_behavioral_response_info(dataset, inplace=False):
+def annotate_stimuli(dataset, inplace=False):
     '''
     adds the following columns to the stimulus_presentations table, facilitating calculation
     of behavior performance based entirely on the stimulus_presentations table:

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -949,6 +949,7 @@ def get_annotated_stimulus_presentations(ophys_experiment):
     # add pre-change, pre-omission, lick on next flash etc
     stimulus_presentations['pre_change'] = stimulus_presentations['is_change'].shift(-1)
     stimulus_presentations['pre_omitted'] = stimulus_presentations['omitted'].shift(-1)
+    stimulus_presentations['post_omitted'] = stimulus_presentations['omitted'].shift(1)
     stimulus_presentations['licked'] = [True if len(licks) > 0 else False for licks in stimulus_presentations.licks.values]
     stimulus_presentations['lick_on_next_flash'] = stimulus_presentations['licked'].shift(-1)
 

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -720,14 +720,8 @@ def add_mean_pupil_to_stimulus_presentations(stimulus_presentations, eye_trackin
         stimulus_presentations = add_mean_pupil_to_stimulus_presentations(stimulus_presentations, eye_tracking, column_to_use='pupil_area')  # noqa E501
     '''
 
-    # set all timepoints that are likely blinks to NaN for all eye_tracking columns
-    eye_tracking.loc[eye_tracking['likely_blink'], :] = np.nan
-    # compute pupil_diameter or radius from pupil_area
-    if column_to_use == 'pupil_diameter':
-        eye_tracking['pupil_diameter'] = np.sqrt(eye_tracking.pupil_area) / np.pi  # convert pupil area to pupil diameter
-    elif column_to_use == 'pupil_radius':
-        eye_tracking['pupil_radius'] = np.sqrt(eye_tracking['pupil_area'] * (1 / np.pi)) # convert pupil area to pupil radius
-
+    eye_tracking = get_pupil_data(eye_tracking, interpolate_likely_blinks=True, normalize_to_gray_screen=True, zscore=False,
+                   interpolate_to_ophys=False, ophys_timestamps=None, stimulus_presentations=stimulus_presentations)
 
     eye_tracking_timeseries = eye_tracking[column_to_use].values
     mean_pupil_around_stimulus = stimulus_presentations.apply(
@@ -898,7 +892,7 @@ def get_annotated_stimulus_presentations(ophys_experiment):
     try:
         stimulus_presentations = add_mean_pupil_to_stimulus_presentations(stimulus_presentations,
                                                                            ophys_experiment.eye_tracking,
-                                                                           column_to_use='pupil_diameter',
+                                                                           column_to_use='pupil_width',
                                                                            time_window=[0, 0.75])
     except:
         print('could not add mean pupil to stimulus presentations, length of eye_tracking attribute is', len(ophys_experiment.eye_tracking))

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -218,6 +218,7 @@ def get_stimulus_response_xr(ophys_experiment,
             t_end=time_window[1],
             output_format='wide',
             interpolate=interpolate,
+            output_sampling_rate=output_sampling_rate
             **kwargs
         )
 
@@ -350,6 +351,7 @@ def get_stimulus_response_df(ophys_experiment,
         time_window=time_window,
         response_window_duration=response_window_duration,
         interpolate=interpolate,
+        output_sampling_rate=output_sampling_rate,
         compute_means=compute_means,
         compute_significance=compute_significance,
         **kwargs)

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -836,7 +836,7 @@ def add_trials_data_to_stimulus_presentations_table(stimulus_presentations, tria
                     'hit', 'miss', 'false_alarm', 'correct_reject',
                     'response_time', 'response_latency', 'reward_time', 'reward_volume', ]]
     # merge trials columns into stimulus_presentations
-    stimulus_presentations = stimulus_presentations.reset_index().merge(trials, on='trials_id')
+    stimulus_presentations = stimulus_presentations.reset_index().merge(trials, on='trials_id', how='left')
     stimulus_presentations = stimulus_presentations.set_index('stimulus_presentations_id')
     return stimulus_presentations
 


### PR DESCRIPTION
- [x] makes `stimulus_response_df `compatible with behavior timeseries including `running_speed`, `pupil_width`, and `lick_rate`
- [x] adds a function to create licks_df, a dataframe with a 0 or 1 for every stimulus timestamp in the session indicating whether there was a lick or not, used to compute time aligned traces for `lick_rate`
- [ ] adds a function to load pupil data, filter out likely blinks, and z-score relative to the 5 min gray screen period at the beginning of the session to account for session to session variability in pupil measurement
- [x] adds `p_value_gray_screen `to `stimulus_response_df `to compute p-value of cell activity in response to a given stimulus compared to a shuffled distribution from the 5 minute gray screen periods and beginning and end of session
- [ ] allows flexible choice of `response_window_duration `to calculate the `mean_response `for each stimulus (for example, now can compute mean in 0.25s window instead of 0.5s)
- [x] adds functions to annotate stimulus_presentations with reward rate, epoch labels, trial information (ex: hit vs miss) engagement state, time from last change
- [ ] TBD: time from last lick, time from last omission 
- [ ] TBD: licks dataframe annotated with lick bouts, consumption licks, etc. 