### PR TITLE
[WIP] update stimulus_response_df code

### DIFF
--- a/mindscope_utilities/general_utilities.py
+++ b/mindscope_utilities/general_utilities.py
@@ -183,7 +183,7 @@ def eventlocked_traces(traces_array, event_indices, start_ind_offset, end_ind_of
     Returns:
         sliced_dataout (np.ndarray): shape (nSamples, nEvents, nCells)
     '''
-    all_inds = event_indices + np.arange(start_ind_offset, end_ind_offset)[:, None] # takes a slice around all event_indices
+    all_inds = event_indices + np.arange(start_ind_offset, end_ind_offset)[:, None]  # takes a slice around all event_indices
     sliced_dataout = traces_array.T[all_inds]
     return sliced_dataout
 

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -287,8 +287,7 @@ def get_stimulus_response_xr(ophys_experiment,
             ophys_experiment.stimulus_presentations,
             ophys_experiment.ophys_timestamps,
             traces_array,
-            response_window_duration *
-            output_sampling_rate,
+            response_window_duration * output_sampling_rate,
             output_sampling_rate)
     except BaseException:
         p_value_gray_screen = np.zeros(mean_responses.shape)
@@ -442,8 +441,7 @@ def get_p_value_from_shuffled_spontaneous(mean_responses,
         ophys_frame_rate = 1 / np.diff(ophys_timestamps).mean()
 
     trace_len = np.round(
-        response_window_duration *
-        ophys_frame_rate).astype(int)
+        response_window_duration * ophys_frame_rate).astype(int)
     start_ind_offset = 0
     end_ind_offset = trace_len
     # get an x frame segment of each cells trace after each shuffled
@@ -833,8 +831,7 @@ def add_mean_pupil_to_stimulus_presentations(
             row["start_time"] + time_window[0],
             row["start_time"] + time_window[1],
         ), axis=1,)
-    stimulus_presentations["mean_" +
-                           column_to_use] = mean_pupil_around_stimulus
+    stimulus_presentations["mean_" + column_to_use] = mean_pupil_around_stimulus
     return stimulus_presentations
 
 

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -930,7 +930,7 @@ def add_time_from_last_change_to_stimulus_presentations(stimulus_presentations):
 
 
 
-def get_annotated_stimulus_presentations(ophys_experiment):
+def get_annotated_stimulus_presentations(ophys_experiment, epoch_duration_mins=10):
     """
     Takes in an ophys_experiment dataset object and returns the stimulus_presentations table with additional columns.
     Adds several useful columns to the stimulus_presentations table, including the mean running speed and pupil diameter for each stimulus,
@@ -960,7 +960,7 @@ def get_annotated_stimulus_presentations(ophys_experiment):
     stimulus_presentations = add_reward_rate_to_stimulus_presentations(stimulus_presentations, ophys_experiment.trials)
     stimulus_presentations = add_epochs_to_stimulus_presentations(stimulus_presentations,
                                                                    time_column='start_time',
-                                                                   epoch_duration_mins=10)
+                                                                   epoch_duration_mins=epoch_duration_mins)
     stimulus_presentations = add_trials_data_to_stimulus_presentations_table(stimulus_presentations, ophys_experiment.trials)
     # add engagement state based on reward rate - note this reward rate is calculated differently than the SDK version
     stimulus_presentations = add_engagement_state_to_stimulus_presentations(stimulus_presentations, ophys_experiment.trials)

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -960,7 +960,7 @@ def get_annotated_stimulus_presentations(ophys_experiment):
     stimulus_presentations = add_reward_rate_to_stimulus_presentations(stimulus_presentations, ophys_experiment.trials)
     stimulus_presentations = add_epochs_to_stimulus_presentations(stimulus_presentations,
                                                                    time_column='start_time',
-                                                                   epoch_duration_mins=5)
+                                                                   epoch_duration_mins=10)
     stimulus_presentations = add_trials_data_to_stimulus_presentations_table(stimulus_presentations, ophys_experiment.trials)
     # add engagement state based on reward rate - note this reward rate is calculated differently than the SDK version
     stimulus_presentations = add_engagement_state_to_stimulus_presentations(stimulus_presentations, ophys_experiment.trials)

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -256,13 +256,18 @@ def get_stimulus_response_xr(ophys_experiment,
     # get mean response for each trial
     mean_responses = stimulus_response_xr.mean_response.data.T  # input needs to be array of nConditions, nCells
 
-    # compute significance of each trial, returns array of nConditions, nCells
-    p_value_gray_screen = get_p_value_from_shuffled_spontaneous(mean_responses,
-                                                                ophys_experiment.stimulus_presentations,
-                                                                ophys_experiment.ophys_timestamps,
-                                                                traces_array,
-                                                                response_window_duration*output_sampling_rate,
-                                                                output_sampling_rate)
+    try:
+        # compute significance of each trial, returns array of nConditions, nCells
+        p_value_gray_screen = get_p_value_from_shuffled_spontaneous(mean_responses,
+                                                                    ophys_experiment.stimulus_presentations,
+                                                                    ophys_experiment.ophys_timestamps,
+                                                                    traces_array,
+                                                                    response_window_duration*output_sampling_rate,
+                                                                    output_sampling_rate)
+    except:
+        p_value_gray_screen = np.zeros(mean_responses.shape)
+
+    print(p_value_gray_screen.shape)
 
     # put p_value_gray_screen back into same coordinates as xarray and make it an xarray data array
     p_value_gray_screen = xr.DataArray(data=p_value_gray_screen.T, coords=stimulus_response_xr.mean_response.coords)

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -920,6 +920,7 @@ def add_time_from_last_change_to_stimulus_presentations(stimulus_presentations):
 
 def get_annotated_stimulus_presentations(ophys_experiment):
     """
+    Takes in an ophys_experiment dataset object and returns the stimulus_presentations table with additional columns.
     Adds several useful columns to the stimulus_presentations table, including the mean running speed and pupil diameter for each stimulus,
     the times of licks for each stimulus, the rolling reward rate, an identifier for 10 minute epochs within a session,
     whether or not a stimulus was a pre-change or pre or post omission, and whether change stimuli were hits or misses
@@ -962,7 +963,7 @@ def get_annotated_stimulus_presentations(ophys_experiment):
 
 
 
-def annotate_stimulus_presentations_with_behavioral_response_info(dataset, inplace=False):
+def annotate_stimuli(dataset, inplace=False):
     '''
     adds the following columns to the stimulus_presentations table, facilitating calculation
     of behavior performance based entirely on the stimulus_presentations table:

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -949,6 +949,7 @@ def get_annotated_stimulus_presentations(ophys_experiment):
     # add pre-change, pre-omission, lick on next flash etc
     stimulus_presentations['pre_change'] = stimulus_presentations['is_change'].shift(-1)
     stimulus_presentations['pre_omitted'] = stimulus_presentations['omitted'].shift(-1)
+    stimulus_presentations['post_omitted'] = stimulus_presentations['omitted'].shift(1)
     stimulus_presentations['licked'] = [True if len(licks) > 0 else False for licks in stimulus_presentations.licks.values]
     stimulus_presentations['lick_on_next_flash'] = stimulus_presentations['licked'].shift(-1)
 


### PR DESCRIPTION
Updates to:

- [x] skip mean pupil computation if there is no eye tracking
- [x] option to include invalid ROIs in cases where all ROIs are provided (useful for debugging)
- [x] changes default epoch duration to 10 mins instead of 5 and provide it as an argument to `get_annotated_stimulus_presentations`
- [x] incorporates changes in PR #60 