### PR TITLE
output_sampling_rate None when interpolate is False

### DIFF
--- a/mindscope_utilities/__init__.py
+++ b/mindscope_utilities/__init__.py
@@ -1,4 +1,4 @@
 from .general_utilities import *  # noqa: F401,F403
-from .plotting_utilities import *  # noqa: F401,F403
+# from .plotting_utilities import *  # noqa: F401,F403
 
 __version__ = "0.1.9"

--- a/mindscope_utilities/general_utilities.py
+++ b/mindscope_utilities/general_utilities.py
@@ -129,7 +129,7 @@ def slice_inds_and_offsets(data_timestamps, stim_timestamps, time_window, sampli
         [start_offset, end_offset] in seconds
     sampling_rate : float, optional, default=None
         Sampling rate of the datatrace.
-        If left as None, samplng rate is inferred from data_timestamps.
+        If left as None, sampling rate is inferred from data_timestamps.
 
     Returns:
     --------
@@ -320,11 +320,6 @@ def stim_triggered_response(data, t, y, stim_times, t_start=None, t_end=None, t_
     assert t_before is None or t_start is None, 'cannot pass both t_start and t_before'  # noqa: E501
     assert t_after is None or t_end is None, 'cannot pass both t_after and t_end'  # noqa: E501
 
-    if interpolate is False:
-        output_sampling_rate = None
-        # MG - commenting this out because it crashes my code when interpolate = False, even if output_sampling_rate = None
-        # assert output_sampling_rate is None, 'if interpolation = False, the sampling rate of the input timeseries will be used. Do not specify output_sampling_rate'  # NOQA E501
-
     # assign time values to t_start and t_end
     if t_start is None:
         t_start = -1 * t_before
@@ -352,6 +347,8 @@ def stim_triggered_response(data, t, y, stim_times, t_start=None, t_end=None, t_
     # ensure that t_end is greater than t_start
     assert t_end > t_start, 'must define t_end to be greater than t_start'
 
+    if interpolate is False:
+        output_sampling_rate = None
     if output_sampling_rate is None:
         # if sampling rate is None,
         # set it to be the mean sampling rate of the input data
@@ -397,12 +394,13 @@ def stim_triggered_response(data, t, y, stim_times, t_start=None, t_end=None, t_
     # if interpolate is False,
     # we will calculate a common timebase and
     # shift every response onto that timebase
+    # Also, sampling rate must be the same as in the input data
     else:
         stim_indices, start_ind_offset, end_ind_offset, trace_timebase = slice_inds_and_offsets(  # NOQA E501
             np.array(data[t]),
             np.array(stim_times),
             time_window=[t_start, t_end],
-            sampling_rate=None,
+            sampling_rate=output_sampling_rate,
             include_endpoint=True
         )
         all_inds = stim_indices + \

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -628,8 +628,6 @@ def get_stimulus_response_df(ophys_experiment,
         **kwargs)
 
     # set up identifier columns depending on whether behavioral or neural data is being used
-    # if (data_type == 'running_speed') or (data_type == 'pupil_diameter') or
-    # (data_type == 'lick_rate'):
     if ('lick' in data_type) or (
             'pupil' in data_type) or ('running' in data_type):
         # set up variables to handle only one timeseries per stim instead of

--- a/mindscope_utilities/visual_behavior_ophys/data_formatting.py
+++ b/mindscope_utilities/visual_behavior_ophys/data_formatting.py
@@ -1505,10 +1505,10 @@ def get_pupil_data(
         ophys_timestamps=None,
         stimulus_presentations=None):
     """
-    Takes eye_tracking attribute of AllenSDK BehaviorOphysExperiment objection and optionally 
+    Takes eye_tracking attribute of AllenSDK BehaviorOphysExperiment objection and optionally
     removes 'likely_blinks' from all columns in dataframe,
     interpolates over NaNs resulting from removing likely_blinks if interpolate = True,
-    normalizes to the 5 minute gray screen period at the beginning of each ophys session, 
+    normalizes to the 5 minute gray screen period at the beginning of each ophys session,
     z-scores the timeseries, and/or aligns to ophys timestamps
 
     :param eye_tracking: eye_tracking attribute of AllenSDK BehaviorOphysExperiment object
@@ -1517,7 +1517,7 @@ def get_pupil_data(
     :param zscore: Boolean, whether or not to z-score the eye tracking values
     :param interpolate_to_ophys: Boolean, whether or not to interpolate eye tracking timestamps on to ophys timestamps
     :param ophys_timestamps: ophys_timestamps attribute of AllenSDK BehaviorOphysExperiment object, required to interpolate to ophys
-    :param stimulus_presentations: stimulus_presentations attribute of AllenSDK BehaviorOphysExperiment object, 
+    :param stimulus_presentations: stimulus_presentations attribute of AllenSDK BehaviorOphysExperiment object,
                                     required to normaliz to gray screen period
 
 
@@ -1528,7 +1528,6 @@ def get_pupil_data(
     # set index to timestamps so they dont get overwritten by subsequent
     # operations
     eye_tracking = eye_tracking.set_index('timestamps')
-
 
     # add timestamps column in addition to index so it can be used as a column as well
     eye_tracking['timestamps'] = eye_tracking.index.values
@@ -1542,7 +1541,6 @@ def get_pupil_data(
     # interpolate over likely blinks, which are now NaNs
     if interpolate_likely_blinks:
         eye_tracking = eye_tracking.interpolate()
-
 
     # divide all columns by average value during gray screen period prior to behavior session
     if normalize_to_gray_screen:


### PR DESCRIPTION
When not interpolating, output_sampling_rate must be none.
Adding this to the code.

Also, removing import .plotting_utilities because it does not exist anymore (why?)